### PR TITLE
docs: polish README — usage, model-testing guide, and an appendable dev timeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A local-first agentic coding harness written in Rust, purpose-built for **small 
 
 Ferric is the Rust synthesis of the Animus lineage — [Animus](https://github.com/crussella0129/Animus) (Python), [Animus_Prion](https://github.com/crussella0129/Animus_Prion) (Go), and [fev](https://github.com/crussella0129/fev) (Go) — built on three convictions:
 
-1. **The harness should own decoding.** Constrained generation (llguidance-style JSON-Schema/regex/CFG grammars) driven end-to-end in the agent loop, so malformed tool calls are impossible rather than repairable.
+1. **The harness should own decoding.** Constrained generation (JSON-Schema / regex / CFG grammars) is driven end-to-end in the agent loop, so malformed tool calls are *impossible* rather than repairable.
 2. **Behavior should scale to the model, deterministically.** A pure function maps a model profile (params, quant, context, measured capability level) to a run policy (protocol, plan granularity, turn budgets, tool count). Small models get small steps.
 3. **The trajectory is the source of truth.** Every session writes a versioned JSONL trace — full conversation, tool calls, untruncated tool output, execution chain — replayable and diffable. If it isn't in the trace, it didn't happen.
 
@@ -20,10 +20,91 @@ Rust is not an implementation detail: the visible, demonstrable chain of ownersh
 |---|---|
 | `ferric-core` | Shared types + the deterministic scale function (ModelProfile → RunPolicy) |
 | `ferric-trace` | Versioned TraceEvent schema, flush-per-event JSONL sink, tolerant reader |
-| `ferric-provider` | Async `Provider` trait (constraint-carrying) + deterministic mock; real backends from s1 |
+| `ferric-provider` | Async `Provider` trait (constraint-carrying) + deterministic mock; real backends behind feature flags |
 | `ferric-guard` | Hardcoded security: workspace boundary, permission checker, deny lists |
 | `ferric-tools` | Tool trait, registry chokepoint, builtin file tools |
 | `ferric-cli` | The `ferric` binary |
+
+## Build
+
+You need a recent stable Rust toolchain (`rustup`, edition 2024). Inference backends are **feature-gated** — pick the one(s) you want:
+
+```sh
+git clone https://github.com/crussella0129/Animus_Ferric.git
+cd Animus_Ferric
+
+# Recommended: the OpenAI-compatible HTTP valve — the constrained-decoding path.
+# Talks to llama.cpp (llama-server), Ollama, or vLLM.
+cargo build --release -p ferric-cli --features backend-openai
+
+# Optional: also the in-process mistral.rs GGUF backend (text-only TextXml path).
+cargo build --release -p ferric-cli --features backend-openai,backend-mistralrs
+```
+
+The binary lands at `target/release/ferric` (`ferric.exe` on Windows). Built with **no** backend feature, only the trace tooling works; `query`/`toolbench` will tell you to rebuild with a feature. Examples below assume `ferric` is on your `PATH`.
+
+## Using Ferric
+
+| Command | What it does |
+|---|---|
+| `ferric server up\|status\|doctor\|down` | Launch & manage the local OpenAI-compatible inference server (the HTTP valve), bound to `127.0.0.1` only. Writes `.ferric/server.json` so other commands auto-discover it. |
+| `ferric query "<prompt>"` | Run one workspace-scoped agent turn against a local model. |
+| `ferric toolbench` | Measure & diagnose tool-calling fire rate for a model (or a fleet — see below). |
+| `ferric bench` | Run the L0–L6 capability ladder and calibrate a model's `measured_level`. |
+| `ferric trace cat <file.jsonl>` | Render a session trace as a human-readable log. |
+
+A typical loop — bring a server up, point Ferric at it, work, tear it down:
+
+```sh
+ferric server up --engine ollama --model qwen2.5-coder:7b   # or --engine llama-server --model your.gguf
+ferric server status                                        # prints base URL + health
+ferric query "list the Rust files and summarize lib.rs"     # auto-discovers the server
+ferric server down
+```
+
+`query` and `toolbench` **auto-discover** the running server from `.ferric/server.json` — no `--api-base` needed. To target a server you didn't launch (e.g. an already-running Ollama), pass `--api-base http://localhost:11434/v1`. By default `query` runs the **constrained** path, which is the reliable one for small models.
+
+## Test it with your own models
+
+Ferric works with large and small models alike, but *how well* a small model drives the tools varies — so don't take it on faith, **measure it**. The testbench runs every tool many times, classifies *why* it misses, and grades the result, so you can dial a model down until quality drops.
+
+**1. Bring a model.** Any of:
+
+```sh
+# Ollama — pull whatever you want to test:
+ollama pull qwen2.5-coder:7b
+
+# llama.cpp — point the launcher at a GGUF on disk (needs `llama-server` on PATH):
+ferric server up --engine llama-server --model /path/to/your-model.gguf [--mmproj mmproj.gguf] [--ctx 8192]
+
+# In-process GGUF (mistral.rs, text-only path) — no server needed:
+ferric toolbench --backend mistral --model-dir /path/to/models --model-file your-model.gguf
+```
+
+**2. Benchmark it** under the constrained path, and write a report:
+
+```sh
+ferric toolbench --backend openai --model <name> --protocol grammar --iterations 20 --report report.md
+```
+
+**3. Read the verdict.** `report.md` gives each tool a success rate, a **failure taxonomy** (`wrong_tool` / `malformed_args` / `no_action` / `parse_error`), and an acceptability band — **solid** (≥90%) / **marginal** (≥70%) / **unreliable** (<70%). Add `--protocol native` to compare the unconstrained path on the same model.
+
+**4. Calibrate a whole fleet at once.** `--models <a,b,c>` benches each model and ranks them into one leaderboard, sorted best→worst — so you can pick the smallest model that's still *solid*:
+
+```sh
+ferric toolbench --backend openai --models qwen2.5-coder:7b,llama3.1:8b,llama3.2:1b --protocol grammar --report fleet.md
+```
+
+```
+# Fleet Leaderboard
+| Model              | Protocol        | Success | Rate   | Verdict |
+|--------------------|-----------------|---------|--------|---------|
+| qwen2.5-coder:7b   | ConstrainedJson | 50/50   | 100.0% | solid   |
+| llama3.1:8b        | ConstrainedJson | 50/50   | 100.0% | solid   |
+| llama3.2:1b        | ConstrainedJson | 50/50   | 100.0% | solid   |
+```
+
+That run is real: the constrained path holds at **100% down to a 1B model**, where the same model's *native* tool-calling collapses to 22% — which is the whole point of harness-owned decoding. Full walkthrough: [docs/testbench.md](docs/testbench.md).
 
 ## Portability
 
@@ -31,33 +112,23 @@ CPU-first. The baseline target includes Raspberry Pi / Orange Pi class aarch64 h
 
 ## Status
 
-Active development (sprint 8). Two inference backends ship behind feature flags:
+Active development (sprint 9). Two inference backends ship behind feature flags:
 
-- **`backend-mistralrs`** — in-process mistral.rs GGUF, driven text-only via the loop's `TextXml` protocol (its server-side constrained path hangs upstream; see ADR-020).
-- **`backend-openai`** — an OpenAI-compatible HTTP valve (llama.cpp / Ollama / vLLM) that enforces a harness-authored JSON-Schema constraint server-side. This is the constrained-decoding thesis working for small GGUF models: out-of-process, with pure-Rust on Ferric's side.
+- **`backend-openai`** — an OpenAI-compatible HTTP valve (llama.cpp / Ollama / vLLM) that enforces a harness-authored JSON-Schema constraint server-side. This is the constrained-decoding thesis working for small GGUF models — out-of-process, with pure Rust on Ferric's side. **It's the default and the reliable path.**
+- **`backend-mistralrs`** — in-process mistral.rs GGUF, driven text-only via the loop's `TextXml` protocol. As of 0.8.15 the old constrained-decoding hang (ADR-020) is fixed upstream, but the constraint still isn't enforced through it (ADR-025) — so it stays the unconstrained fallback.
 
 The action protocol (`NativeTools` / `ConstrainedJson` / `TextXml`) is chosen from each backend's real capabilities. An embedded PyO3/PyTorch backend was tried and removed (ADR-021) — external engines are reached only via the out-of-process valve. Development follows a sprint-loop protocol; see `decisions.md` for ADRs and `agent-tasks/` for the ledger.
 
-## First run — the testbench
+## Development timeline
 
-Ferric works with large and small models alike, but *how well* a small model drives the tools varies. The testbench tells you: it runs every tool many times, classifies *why* it misses, and grades the result — so you can dial a model down until quality drops.
+Ferric is built in **sprints** — a Research → Plan → Build → Test → Loop protocol. The durable record lives in `decisions.md` (the full ADR log) and `agent-tasks/` (the task ledger); this is the human-readable summary. *Newest last — append the next sprint here as it closes.*
 
-```sh
-# 1. Bring up a local OpenAI-compatible server (llama.cpp by default; Ollama pluggable):
-ferric server up --engine llama-server --model path/to/model.gguf
-#    (multimodal: add --mmproj path/to/mmproj.gguf · or:  --engine ollama --model qwen2.5-coder:7b)
+- **Sprint 0 — Foundations** (2026-06-10). Cargo workspace + six crates; the deterministic scale function (ModelProfile → RunPolicy); versioned JSONL trace; hardcoded security (workspace boundary, deny lists); builtin file tools; CLI stub. *ADR-001–009.*
+- **Sprint 1 — The agent loop** (2026-06-11). Turn loop with policy budgets, a structured task-complete terminator, a repetition guard, and retry backoff; a command structure with no chat catch-all. *ADR-010–014.*
+- **Sprint 2 — Action grammar & calibration** (2026-06-13). The unified `ActionProtocol` grammar; per-tier output-token budgets; the `bench` L0–L6 capability ladder as the sole producer of `measured_level`. The server-side constrained-decoding **hang** surfaces and is quarantined opt-in. *ADR-015–020.*
+- **Sprints 3–6 — Exploration** (mid-June 2026). An embedded PyO3/PyTorch inference path and a first-generation toolbench. This era drifted from the *harness-owns-decoding* thesis — and set up the realignment.
+- **Sprint 7 — The realignment** (2026-06-23). The PyO3/PyTorch backend removed; external engines reached only through the out-of-process HTTP valve. The constraint reinstated, capabilities made honest, and the `NativeTools` / `ConstrainedJson` / `TextXml` trichotomy chosen from each backend's *real* capabilities; toolbench rebuilt around the active protocol. *ADR-021–023.*
+- **Sprint 8 — Launcher + testbench** (2026-06-23). The `ferric server` lifecycle manager (llama-server default, Ollama pluggable, runfile auto-discovery) and the diagnostic toolbench (failure taxonomy + verdict bands). **Thesis proven on a real model: constrained 100% vs native 0% on the same Ollama model.** *ADR-024.*
+- **Sprint 9 — Fleet calibration** (2026-06-23). `ferric toolbench --models` sweeps a fleet into one sorted leaderboard. **The constraint holds 100% down to a 1B model where native collapses to 22%** — it extends the usable model floor to 1B. A native-`content` fallback closes the "Ollama returns the call as text" gap; the mistral.rs 0.8.15 probe confirmed the hang is fixed upstream but the constraint still isn't enforced. *ADR-025.*
 
-# 2. Benchmark tool-calling fire rate under the constrained path, and write a report:
-ferric toolbench --backend openai --model <name> --protocol grammar --report report.md
-
-# 3. Read report.md: per-tool success rate, a failure taxonomy
-#    (wrong_tool / malformed_args / no_action / parse_error), and a verdict band
-#    (solid >=90% / marginal >=70% / unreliable <70%). Try a smaller model and re-run.
-
-# …or sweep a whole fleet in one shot and rank them best→worst:
-ferric toolbench --backend openai --models qwen2.5-coder:7b,llama3.1:8b --protocol grammar --report fleet.md
-
-ferric server down   # stop it when done
-```
-
-`ferric query` and `ferric toolbench` **auto-discover** the running server (no `--api-base` needed — it's read from `.ferric/server.json`). `--models <a,b,c>` benches a fleet into one sorted leaderboard so you can pick the smallest model that's still *solid*. `ferric server doctor` checks your engine binary + model before you start. Full walkthrough: [docs/testbench.md](docs/testbench.md).
+> **Next — Sprint 10: multimodal "any file" input** (audio / video / image through the valve, capability-gated), per ADR-023/025.


### PR DESCRIPTION
## Summary
Overhauls the README from a single "First run" section into a full guide:
- **Build** — the feature-flag reality (`backend-openai` for the constrained valve, `+backend-mistralrs` for the in-process GGUF path; where the binary lands; the "no feature = trace tools only" caveat).
- **Using Ferric** — a command-reference table (`server` / `query` / `toolbench` / `bench` / `trace`) plus the typical up → query → down loop and how auto-discovery vs `--api-base` works.
- **Test it with your own models** — reframed from "First run" to be model-agnostic: three ways to bring a model (Ollama pull, llama.cpp GGUF, in-process mistral.rs), then benchmark → read the verdict bands → fleet-calibrate.
- **Status** — bumped to sprint 9 with the honest backend split.
- **Development timeline** — sprints 0→9 as one-liners with dates + ADR refs, marked *newest-last / appendable* so each future sprint close just adds a bullet, with a `Next — Sprint 10` pointer.

## Why
The README explained the philosophy but not how to **build, run, or evaluate models** with the tool. This makes it usable by someone arriving cold, and gives the project a running history each sprint close can append to.

## What a reviewer should know
- **Docs-only.** The diff is `README.md`. The sprint 8–9 *code* it documents already merged to `main` (PR #1); this branch is one commit ahead with just the README.
- The timeline is grounded in the durable record (`decisions.md` ADR headers + `agent-tasks/completed-tasks.md`) — including representing the **sprints 3–6 exploration era** honestly (the pre-realignment PyO3/PyTorch path that sprint 7 corrected).
- The example fleet leaderboard (100% solid down to a 1B model) is a **real sprint-9 run**, not illustrative filler.
- Logo + rendered timeline are a "does this read right" judgment call worth a skim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)