### PR TITLE
Sandbox mount (ADR-101), CLI cleanup (--backend + --sink-action), PATH install docs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,9 +25,10 @@ license = "MIT OR Apache-2.0"
 repository = "https://github.com/crussella0129/Animus_Ferric"
 
 # Dependency allowlist (ADR-004, amended s1): the s0 set plus — clap (the CLI
-# surface is real now), rustyline (for the chat REPL), and feature-gated 
-# mistralrs + tokio (default OFF: the default workspace build and the aarch64 
-# check gate never compile them).
+# surface is real now), rustyline (for the chat REPL), and tokio (the async
+# runtime the OpenAI HTTP backend and the CLI drive; the pure-library default
+# build and the aarch64 check gate never pull it). The in-process mistralrs
+# path was removed (ADR-027), so it is no longer in this allowlist.
 [workspace.dependencies]
 serde = { version = "1", features = ["derive"] }
 # preserve_order is LOAD-BEARING (ADR-016): llguidance emits JSON-schema

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ cd Animus_Ferric
 cargo build --release -p ferric-cli --features backend-openai
 ```
 
-The binary lands at `target/release/ferric` (`ferric.exe` on Windows). Built with **no** backend feature, only the trace tooling works; `query`/`toolbench` will tell you to rebuild with a feature.
+The binary lands at `target/release/ferric` (`ferric.exe` on Windows). Built with **no** backend feature, only the trace tooling works; `query`/`bench` will tell you to rebuild with a feature.
 
 **Put `ferric` on your `PATH`** (the examples below assume it is). The portable way — identical on Windows, Linux, and macOS — is `cargo install`, which builds in release *and* drops the binary into `~/.cargo/bin` (rustup already adds that directory to your `PATH`):
 
@@ -86,13 +86,13 @@ ferric server down
 > [!NOTE]
 > If you run `ferric server up --tailscale` on a machine for the first time, you must authorize Tailscale Serve on your Tailnet. The command will output an authorization link that you must click to unblock the proxy and register the server globally.
 
-`query` and `toolbench` **auto-discover** the running server from `.ferric/server.json` (or your global `APPDATA` directory) — no `--api-base` needed. To target a server you didn't launch (e.g. an already-running Ollama), pass `--api-base http://localhost:11434/v1`. By default `query` runs the **constrained** path, which is the reliable one for small models.
+`query` and `bench` **auto-discover** the running server from `.ferric/server.json` (or your global `APPDATA` directory) — no `--api-base` needed. To target a server you didn't launch (e.g. an already-running Ollama), pass `--api-base http://localhost:11434/v1`. By default `query` runs the **constrained** path, which is the reliable one for small models.
 
 `ferric query` also takes **any file** as input with `--file` (repeatable): text/code files fold into the prompt (works on any model), while image/audio/video attach as content parts when you declare `--modality` and the model can read them (Gemma 3n on the OpenAI valve). See [docs/multimodal.md](docs/multimodal.md).
 
 Add `--stream` to see text live as it's generated instead of waiting for the whole multi-turn loop to finish (opt-in; ADR-047).
 
-**Builtin tools** (all workspace-scoped and security-checked through the guard). The always-on **core** (Ring 0) is the navigate/mutate set: `read_file`, `list_dir`, `write_file`, `make_dir`, `edit_file` (surgical first-occurrence replace — small models do targeted edits far more reliably than full rewrites), and `delete_path` (file or, with `recursive`, a directory). **Ring 1** ("find & organize") adds four: `search_files` (grep-style *content* search → `relpath:lineno:line`), `find_files` (find files by *name* → relpaths), `move_path` (move/rename), and `copy_file` — so a small model can locate code and reorganize it once it's proven the core. **Ring 2** ("plan & apply structured changes") seeds with `multi_edit` — an ordered, *atomic* batch of edits to one file (all-or-nothing; reachable once a model earns the Medium tier). Tool vocabularies are organized as **rings** that widen as a model proves it can call them reliably, with the active rings forming the constrained grammar. `ferric query --max-ring 0` pins any model to the Ring-0 core — the smallest, surest grammar — regardless of its size (restrict-only; to *widen* a small model's rings, prove it with the toolbench so `measured_level` promotes it).
+**Builtin tools** (all workspace-scoped and security-checked through the guard). The always-on **core** (Ring 0) is the navigate/mutate set: `read_file`, `list_dir`, `write_file`, `make_dir`, `edit_file` (surgical first-occurrence replace — small models do targeted edits far more reliably than full rewrites), and `delete_path` (file or, with `recursive`, a directory). **Ring 1** ("find & organize") adds four: `search_files` (grep-style *content* search → `relpath:lineno:line`), `find_files` (find files by *name* → relpaths), `move_path` (move/rename), and `copy_file` — so a small model can locate code and reorganize it once it's proven the core. **Ring 2** ("plan & apply structured changes") seeds with `multi_edit` — an ordered, *atomic* batch of edits to one file (all-or-nothing; reachable once a model earns the Medium tier). Tool vocabularies are organized as **rings** that widen as a model proves it can call them reliably, with the active rings forming the constrained grammar. `ferric query --max-ring 0` pins any model to the Ring-0 core — the smallest, surest grammar — regardless of its size (restrict-only; to *widen* a small model's rings, prove it with `ferric bench ltd` so `measured_level` promotes it).
 
 Beyond the hardcoded guard, a project can drop a **`.ferricignore`** in the workspace root (gitignore-flavored — `secrets/`, `*.pem`, `data/private`) to put more paths off-limits to the agent. It is *additive-only*: it can only ever add denials on top of the hardcoded floor, never relax it (ADR-068), and the file is itself write-protected so the agent can't edit away its own restrictions.
 
@@ -110,7 +110,7 @@ ferric server up --engine llama-server --model /path/to/your-model.gguf [--mmpro
 **2. Benchmark it** under the constrained path, and write a report:
 
 ```sh
-ferric bench ltd --backend openai --model <name> --protocol grammar --iterations 20 --report report.md
+ferric bench ltd --model <name> --protocol grammar --iterations 20 --report report.md
 ```
 
 **3. Read the verdict.** `report.md` gives each tool a success rate, a **failure taxonomy** (`wrong_tool` / `malformed_args` / `no_action` / `parse_error`), and an acceptability band — **solid** (≥90%) / **marginal** (≥70%) / **unreliable** (<70%). Add `--protocol native` to compare the unconstrained path on the same model.
@@ -118,7 +118,7 @@ ferric bench ltd --backend openai --model <name> --protocol grammar --iterations
 **4. Calibrate a whole fleet at once.** `--models <a,b,c>` benches each model and ranks them into one leaderboard, sorted best→worst — so you can pick the smallest model that's still *solid*:
 
 ```sh
-ferric bench ltd --backend openai --models qwen2.5-coder:7b,llama3.1:8b,llama3.2:1b --protocol grammar --report fleet.md
+ferric bench ltd --models qwen2.5-coder:7b,llama3.1:8b,llama3.2:1b --protocol grammar --report fleet.md
 ```
 
 ```

--- a/README.md
+++ b/README.md
@@ -49,7 +49,19 @@ cd Animus_Ferric
 cargo build --release -p ferric-cli --features backend-openai
 ```
 
-The binary lands at `target/release/ferric` (`ferric.exe` on Windows). Built with **no** backend feature, only the trace tooling works; `query`/`toolbench` will tell you to rebuild with a feature. Examples below assume `ferric` is on your `PATH`.
+The binary lands at `target/release/ferric` (`ferric.exe` on Windows). Built with **no** backend feature, only the trace tooling works; `query`/`toolbench` will tell you to rebuild with a feature.
+
+**Put `ferric` on your `PATH`** (the examples below assume it is). The portable way — identical on Windows, Linux, and macOS — is `cargo install`, which builds in release *and* drops the binary into `~/.cargo/bin` (rustup already adds that directory to your `PATH`):
+
+```sh
+cargo install --path crates/ferric-cli --features backend-openai --force
+# or use the wrapper, which does exactly this:
+#   Linux/macOS:  ./tools/install.sh
+#   Windows:      .\tools\install.ps1
+```
+
+> [!IMPORTANT]
+> `cargo install` copies a **snapshot**. After you `git pull` or edit source, re-run it — a plain `cargo build` refreshes `target/release/` but **not** the copy on your `PATH`, so the `ferric` you invoke can silently lag the code (this is how a months-old binary kept offering a `--backend` flag that source had already removed). `--force` re-installs even though the version string (`0.1.0`) never changes.
 
 ## Using Ferric
 

--- a/crates/ferric-bench/src/lib.rs
+++ b/crates/ferric-bench/src/lib.rs
@@ -16,7 +16,7 @@ pub use calibrate::{
 };
 
 pub use results::{ResultRow, append_row, read_rows};
-pub use runner::{Invocation, ModelArgs, OpenAiArgs, RunRecord, WorkspaceHandle, run_spec};
+pub use runner::{Invocation, OpenAiArgs, RunRecord, WorkspaceHandle, run_spec};
 pub use spec::{BenchSpec, ExpectKind, Expectation, embedded_specs};
 pub use verify::{
     ToolVerdict, TraceMetrics, completed, failure_admission, parse_trace, verify_expectations,

--- a/crates/ferric-bench/src/runner.rs
+++ b/crates/ferric-bench/src/runner.rs
@@ -21,22 +21,14 @@ pub struct Invocation {
     /// The `ferric` binary to spawn (default: this executable).
     pub ferric_bin: PathBuf,
     pub protocol: ActionProtocol,
-    /// Mistral GGUF backend removed; kept for CLI compatibility if needed, but unused.
-    pub model: Option<ModelArgs>,
     /// OpenAI-compatible backend (ollama / llama-server — the constrained
-    /// workhorse). Takes precedence over `model`; requires `backend-openai` in
-    /// the spawned binary.
+    /// workhorse), or `None` for `--mock`. The only real backend since the
+    /// in-process mistral.rs GGUF path was removed (ADR-027); `requires
+    /// backend-openai` in the spawned binary.
     pub openai: Option<OpenAiArgs>,
     /// Prompt library dir passed through as `--prompts-dir`.
     pub prompts_dir: Option<PathBuf>,
     pub keep_workspace: bool,
-}
-
-pub struct ModelArgs {
-    pub model_dir: PathBuf,
-    pub model_file: String,
-    pub params_b: f32,
-    pub ctx: u32,
 }
 
 pub struct OpenAiArgs {
@@ -54,7 +46,6 @@ impl Invocation {
         Self {
             ferric_bin: std::env::current_exe().unwrap_or_else(|_| PathBuf::from("ferric")),
             protocol: ActionProtocol::ConstrainedJson,
-            model: None,
             openai: None,
             prompts_dir: None,
             keep_workspace: false,
@@ -163,10 +154,10 @@ fn protocol_flag(p: ActionProtocol) -> &'static str {
 }
 
 /// Build the child `query` argv (excluding the binary). Pure, so the backend
-/// branching is unit-testable without spawning. Precedence: `openai` (the
-/// constrained workhorse — ollama/llama-server) → `model` (mistral GGUF) →
-/// `--mock`. mistral's constrained path hangs (ADR-027), so the openai arm is how
-/// the full loop reaches a real *constrained* model.
+/// branching is unit-testable without spawning. Either the `openai` backend
+/// (the constrained workhorse — ollama/llama-server) or `--mock`; the
+/// in-process mistral.rs GGUF path was removed (ADR-027), so the openai arm is
+/// how the full loop reaches a real *constrained* model.
 fn query_args(prompt: &str, inv: &Invocation, workspace: &Path) -> Vec<String> {
     let mut args = vec![
         "query".to_string(),
@@ -177,8 +168,6 @@ fn query_args(prompt: &str, inv: &Invocation, workspace: &Path) -> Vec<String> {
         protocol_flag(inv.protocol).to_string(),
     ];
     if let Some(o) = &inv.openai {
-        args.push("--backend".to_string());
-        args.push("openai".to_string());
         if let Some(base) = &o.api_base {
             args.push("--api-base".to_string());
             args.push(base.clone());
@@ -190,17 +179,6 @@ fn query_args(prompt: &str, inv: &Invocation, workspace: &Path) -> Vec<String> {
             o.params_b.to_string(),
             "--ctx".to_string(),
             o.ctx.to_string(),
-        ]);
-    } else if let Some(m) = &inv.model {
-        args.extend([
-            "--model-dir".to_string(),
-            m.model_dir.display().to_string(),
-            "--model-file".to_string(),
-            m.model_file.clone(),
-            "--params-b".to_string(),
-            m.params_b.to_string(),
-            "--ctx".to_string(),
-            m.ctx.to_string(),
         ]);
     } else {
         args.push("--mock".to_string());
@@ -247,7 +225,6 @@ mod tests {
         Invocation {
             ferric_bin: PathBuf::from("ferric"),
             protocol: ActionProtocol::ConstrainedJson,
-            model: None,
             openai: None,
             prompts_dir: None,
             keep_workspace: false,
@@ -268,30 +245,13 @@ mod tests {
             ctx: 4096,
         });
         let args = query_args("do a task", &inv, Path::new("/ws"));
-        assert!(has_pair(&args, "--backend", "openai"), "{args:?}");
         assert!(has_pair(&args, "--model", "qwen2.5-coder:7b"));
         assert!(has_pair(&args, "--api-base", "http://localhost:11434/v1"));
         assert!(has_pair(&args, "--protocol", "grammar"));
-        assert!(!args.iter().any(|a| a == "--model-dir"), "no mistral flags");
+        // The single-backend simplification removed `--backend`; the child
+        // `query` no longer accepts it, so the runner must never emit it.
+        assert!(!args.iter().any(|a| a == "--backend"), "{args:?}");
         assert!(!args.iter().any(|a| a == "--mock"));
-    }
-
-    #[test]
-    fn query_args_mistral_arm_unchanged() {
-        let mut inv = base();
-        inv.model = Some(ModelArgs {
-            model_dir: PathBuf::from("/m"),
-            model_file: "f.gguf".to_string(),
-            params_b: 1.0,
-            ctx: 4096,
-        });
-        let args = query_args("t", &inv, Path::new("/ws"));
-        assert!(args.iter().any(|a| a == "--model-dir"));
-        assert!(args.iter().any(|a| a == "--model-file"));
-        assert!(
-            !args.iter().any(|a| a == "--backend"),
-            "mistral arm adds no --backend"
-        );
     }
 
     #[test]

--- a/crates/ferric-cli/src/api.rs
+++ b/crates/ferric-cli/src/api.rs
@@ -220,9 +220,6 @@ pub mod server {
             requested_skills: Vec::new(),
             allowed_skills: Vec::new(),
             mock: args.mock,
-            backend: backend_opts
-                .backend
-                .unwrap_or(crate::backend::BackendArg::Openai),
             params_b: args.params_b.or(cfg.params_b).unwrap_or(1.2),
             quant: args
                 .quant

--- a/crates/ferric-cli/src/backend.rs
+++ b/crates/ferric-cli/src/backend.rs
@@ -1,29 +1,15 @@
-use clap::{Args, ValueEnum};
-use serde::{Deserialize, Serialize};
+use clap::Args;
 
 #[cfg(feature = "backend-openai")]
 use ferric_provider::Provider;
 
-/// `Serialize`/`Deserialize` + kebab-case (T-3801): lets `Config::backend`
-/// (sprint 38's persistent config) round-trip through TOML using the same
-/// spelling clap's own `ValueEnum` already uses (`"openai"`).
-#[derive(Debug, Clone, Copy, ValueEnum, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "kebab-case")]
-pub enum BackendArg {
-    /// OpenAI-compatible HTTP valve (llama.cpp / Ollama). Enforces a
-    /// `response_format` constraint server-side → `ConstrainedJson`.
-    Openai,
-}
-
+/// Connection options for the sole backend — the OpenAI-compatible HTTP valve
+/// (llama.cpp / Ollama), which enforces a `response_format` constraint
+/// server-side → `ConstrainedJson`. The in-process mistral.rs path (ADR-027)
+/// and the `--backend` selector it needed were removed once the valve became
+/// the only backend; a second variant re-enters here trivially if one lands.
 #[derive(Args, Clone)]
 pub struct BackendOpts {
-    /// Which backend to use. Default "openai" when neither this flag nor a
-    /// config file's `backend` is set (T-3803/T-3805) — bare `Option<T>`
-    /// rather than a clap default so a config-only-set value isn't masked by
-    /// an indistinguishable clap default.
-    #[arg(long, value_enum)]
-    pub backend: Option<BackendArg>,
-
     /// The model string identifier (required for openai backend)
     #[arg(long)]
     pub model: Option<String>,
@@ -53,33 +39,25 @@ fn resolve_base(explicit: Option<&str>, runfile: Option<&str>) -> String {
 pub async fn create_provider(
     opts: &BackendOpts,
 ) -> Result<Box<dyn Provider + Send + Sync>, String> {
-    match opts.backend.unwrap_or(BackendArg::Openai) {
-        BackendArg::Openai => {
-            #[cfg(feature = "backend-openai")]
-            {
-                use ferric_provider::openai::{OpenAiConfig, OpenAiProvider};
-                let model_id = opts.model.clone().unwrap_or_else(|| "default".to_string());
-                let api_key = opts
-                    .api_key
-                    .clone()
-                    .or_else(|| std::env::var("OPENAI_API_KEY").ok());
-                let runfile = std::env::current_dir()
-                    .ok()
-                    .and_then(|d| crate::server::read_runfile(&d));
-                let base_url = resolve_base(
-                    opts.api_base.as_deref(),
-                    runfile.as_ref().map(|r| r.base_url.as_str()),
-                );
-                let config = OpenAiConfig {
-                    base_url,
-                    api_key: api_key.unwrap_or_else(|| "ollama".to_string()),
-                    model: model_id,
-                };
-                let provider = OpenAiProvider::new(config);
-                Ok(Box::new(provider))
-            }
-        }
-    }
+    use ferric_provider::openai::{OpenAiConfig, OpenAiProvider};
+    let model_id = opts.model.clone().unwrap_or_else(|| "default".to_string());
+    let api_key = opts
+        .api_key
+        .clone()
+        .or_else(|| std::env::var("OPENAI_API_KEY").ok());
+    let runfile = std::env::current_dir()
+        .ok()
+        .and_then(|d| crate::server::read_runfile(&d));
+    let base_url = resolve_base(
+        opts.api_base.as_deref(),
+        runfile.as_ref().map(|r| r.base_url.as_str()),
+    );
+    let config = OpenAiConfig {
+        base_url,
+        api_key: api_key.unwrap_or_else(|| "ollama".to_string()),
+        model: model_id,
+    };
+    Ok(Box::new(OpenAiProvider::new(config)))
 }
 
 // No `create_provider` stub for the backend-free build: the callers carry

--- a/crates/ferric-cli/src/bench_cmd.rs
+++ b/crates/ferric-cli/src/bench_cmd.rs
@@ -15,7 +15,6 @@ use ferric_bench::{
 };
 use ferric_core::{ActionProtocol, tier_for_params};
 
-use crate::backend::BackendArg;
 use crate::query::ProtocolArg;
 
 #[derive(Args)]
@@ -31,11 +30,6 @@ pub struct BenchArgs {
     /// Variant label recorded in each results row.
     #[arg(long, default_value = "default")]
     pub variant: String,
-
-    /// Inference backend (without `--mock`): `openai` (ollama / llama-server via `--api-base`/
-    /// `--model` — the constrained workhorse).
-    #[arg(long, value_enum, default_value = "openai")]
-    pub backend: BackendArg,
 
     /// OpenAI-compatible base URL (openai backend; omit to auto-discover a
     /// running `ferric server`).
@@ -128,7 +122,6 @@ pub fn run_bench(args: BenchArgs) -> ExitCode {
             let inv = Invocation {
                 ferric_bin: ferric_bin.clone(),
                 protocol,
-                model: None,
                 openai: Some(OpenAiArgs {
                     api_base: args.api_base.clone(),
                     model: model_id.clone(),
@@ -183,29 +176,24 @@ pub fn run_bench(args: BenchArgs) -> ExitCode {
 
     // Single-model path. openai = ollama/llama-server; `model_name`
     // keys the calibration record (model-id for openai).
-    let (model, openai, model_name) = if args.mock {
-        (None, None, None)
+    let (openai, model_name) = if args.mock {
+        (None, None)
     } else {
-        match args.backend {
-            BackendArg::Openai => {
-                let Some(model_id) = args.model.clone() else {
-                    eprintln!("--model <id> is required for --backend openai");
-                    return ExitCode::FAILURE;
-                };
-                let oa = OpenAiArgs {
-                    api_base: args.api_base.clone(),
-                    model: model_id.clone(),
-                    params_b: args.params_b,
-                    ctx: args.ctx,
-                };
-                (None, Some(oa), Some(model_id))
-            }
-        }
+        let Some(model_id) = args.model.clone() else {
+            eprintln!("--model <id> is required (or use --mock)");
+            return ExitCode::FAILURE;
+        };
+        let oa = OpenAiArgs {
+            api_base: args.api_base.clone(),
+            model: model_id.clone(),
+            params_b: args.params_b,
+            ctx: args.ctx,
+        };
+        (Some(oa), Some(model_id))
     };
     let inv = Invocation {
         ferric_bin,
         protocol,
-        model,
         openai,
         prompts_dir: args.prompts_dir.clone(),
         keep_workspace: args.keep_workspace,

--- a/crates/ferric-cli/src/chat.rs
+++ b/crates/ferric-cli/src/chat.rs
@@ -380,9 +380,6 @@ pub fn run_chat(args: ChatArgs) -> ExitCode {
         requested_skills: Vec::new(),
         allowed_skills: cfg.allowed_skills.clone().unwrap_or_default(),
         mock: args.mock,
-        backend: backend_opts
-            .backend
-            .unwrap_or(crate::backend::BackendArg::Openai),
         params_b: args.params_b.or(cfg.params_b).unwrap_or(1.2),
         quant: args
             .quant
@@ -725,7 +722,6 @@ mod tests {
             requested_skills: Vec::new(),
             allowed_skills: Vec::new(),
             mock: true,
-            backend: crate::backend::BackendArg::Openai,
             params_b: 1.0,
             quant: "Q4_K_M".to_string(),
             family: "test".to_string(),

--- a/crates/ferric-cli/src/config.rs
+++ b/crates/ferric-cli/src/config.rs
@@ -8,11 +8,10 @@ use std::path::{Path, PathBuf};
 
 use serde::Deserialize;
 
-use crate::backend::{BackendArg, BackendOpts};
+use crate::backend::BackendOpts;
 
 #[derive(Clone, Default, Deserialize, PartialEq)]
 pub struct Config {
-    pub backend: Option<BackendArg>,
     pub model: Option<String>,
     pub api_base: Option<String>,
     pub api_key: Option<String>,
@@ -53,7 +52,6 @@ pub struct Config {
 impl std::fmt::Debug for Config {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("Config")
-            .field("backend", &self.backend)
             .field("model", &self.model)
             .field("api_base", &self.api_base)
             // Presence is useful for debugging config precedence; the value
@@ -78,7 +76,6 @@ impl Config {
     /// Project's value wins over user's, field-by-field.
     fn merged_over(self, user: Config) -> Config {
         Config {
-            backend: self.backend.or(user.backend),
             model: self.model.or(user.model),
             api_base: self.api_base.or(user.api_base),
             api_key: self.api_key.or(user.api_key),
@@ -214,7 +211,6 @@ pub fn load_layered(workspace: &Path) -> LoadedConfig {
 /// has ONE call site that's directly unit-testable in isolation, rather than
 /// being inlined at each of the two (previously duplicated) launch sites.
 pub fn merge_backend_opts(mut opts: BackendOpts, cfg: &Config) -> BackendOpts {
-    opts.backend = opts.backend.take().or(cfg.backend);
     opts.model = opts.model.take().or_else(|| cfg.model.clone());
     opts.api_base = opts.api_base.take().or_else(|| cfg.api_base.clone());
     opts.api_key = opts.api_key.take().or_else(|| cfg.api_key.clone());
@@ -344,49 +340,25 @@ mod tests {
         }
     }
 
+    /// Backward-compat: a legacy `backend = "openai"` key (written before the
+    /// single-backend simplification removed the field) must still parse — the
+    /// now-unknown key is ignored, not a hard error — so old
+    /// `.ferric/config.toml` files keep working.
     #[test]
-    fn backend_arg_config_field_uses_kebab_case_spelling() {
-        // Matches clap's own lowercase ValueEnum spelling ("mistral"/"openai").
-        let cfg: Config = toml::from_str("backend = \"openai\"\n").unwrap();
-        assert_eq!(cfg.backend, Some(BackendArg::Openai));
+    fn legacy_backend_key_is_ignored_not_an_error() {
+        let cfg: Config = toml::from_str("backend = \"openai\"\nmodel = \"m\"\n").unwrap();
+        assert_eq!(cfg.model, Some("m".to_string()));
     }
 
     fn no_backend_opts() -> BackendOpts {
         BackendOpts {
-            backend: None,
             model: None,
             api_base: None,
             api_key: None,
         }
     }
 
-    /// Test-critic C-001/C-003: `merge_backend_opts` — the same masking-
-    /// hazard class T-3803's `model_key` fix caught, but for `BackendOpts`'
-    /// own fields — is now directly unit-tested in isolation, not just
-    /// "correct by inspection" at its two call sites.
-    #[test]
-    fn merge_backend_opts_config_only_backend_is_applied() {
-        let cfg = Config {
-            backend: Some(BackendArg::Openai),
-            ..Config::default()
-        };
-        let merged = merge_backend_opts(no_backend_opts(), &cfg);
-        assert_eq!(merged.backend, Some(BackendArg::Openai));
-    }
-
-    #[test]
-    fn merge_backend_opts_cli_flag_wins_over_config() {
-        let cfg = Config {
-            backend: Some(BackendArg::Openai),
-            ..Config::default()
-        };
-        let mut opts = no_backend_opts();
-        opts.backend = Some(BackendArg::Openai);
-        let merged = merge_backend_opts(opts, &cfg);
-        assert_eq!(merged.backend, Some(BackendArg::Openai));
-    }
-
-    /// The remaining five `BackendOpts` fields get the same config-only
+    /// The `BackendOpts` fields get config-only
     /// precedence, in one pass — closing the rest of the C-001-class gap the
     /// critic flagged (not just `backend`).
     #[test]

--- a/crates/ferric-cli/src/icm.rs
+++ b/crates/ferric-cli/src/icm.rs
@@ -34,7 +34,7 @@ use ferric_icm::{ComposeMode, IcmWorkspace, plan, plan_with_mode, scaffold_works
 use ferric_loop::StopReason;
 use ferric_trace::JsonlSink;
 
-use crate::backend::{BackendArg, BackendOpts};
+use crate::backend::BackendOpts;
 use crate::query::{RunConfigArgs, build_run_config, mock_provider, now_ms, run_with_provider};
 
 /// The pipeline's backend, shared with `ferric chat` since sprint 103
@@ -252,7 +252,6 @@ fn run_pipeline(args: IcmRunArgs) -> ExitCode {
         requested_skills: Vec::new(),
         allowed_skills: Vec::new(),
         mock: args.mock,
-        backend: backend_opts.backend.unwrap_or(BackendArg::Openai),
         params_b: args.params_b.or(cfg.params_b).unwrap_or(1.2),
         quant: cfg.quant.clone().unwrap_or_else(|| "Q4_K_M".to_string()),
         family: cfg.family.clone().unwrap_or_else(|| "unknown".to_string()),

--- a/crates/ferric-cli/src/launch.rs
+++ b/crates/ferric-cli/src/launch.rs
@@ -129,7 +129,6 @@ pub fn run_launch(args: LaunchArgs) -> ExitCode {
                     workspace: Some(report.path.clone()),
                     mock: false, // You could add args or let config handle backend etc.
                     backend_opts: crate::backend::BackendOpts {
-                        backend: Some(crate::backend::BackendArg::Openai),
                         model: None,
                         api_base: None,
                         api_key: None,

--- a/crates/ferric-cli/src/launch.rs
+++ b/crates/ferric-cli/src/launch.rs
@@ -149,7 +149,7 @@ pub fn run_launch(args: LaunchArgs) -> ExitCode {
                     research: None,
                     research_urls: Vec::new(),
                     allow_standard_runtime: false,
-                    sink_action: "deny".to_string(),
+                    sink_action: crate::query::SinkActionArg::Deny,
                     accept_edits: false,
                 };
                 return crate::query::run_query(query_args);

--- a/crates/ferric-cli/src/mcp.rs
+++ b/crates/ferric-cli/src/mcp.rs
@@ -539,9 +539,6 @@ impl McpServer {
             requested_skills: Vec::new(),
             allowed_skills: Vec::new(),
             mock: args.mock,
-            backend: backend_opts
-                .backend
-                .unwrap_or(crate::backend::BackendArg::Openai),
             params_b: resolved_params_b,
             quant: resolved_quant,
             family: resolved_family,
@@ -716,7 +713,6 @@ mod tests {
         McpArgs {
             workspace: Some(ws.to_path_buf()),
             backend_opts: crate::backend::BackendOpts {
-                backend: None,
                 model: None,
                 api_base: None,
                 api_key: None,
@@ -874,7 +870,6 @@ mod tests {
             allowed_skills: Vec::new(),
             tier_override: None,
             mock: true,
-            backend: crate::backend::BackendArg::Openai,
             params_b: 1.2,
             quant: "Q4_K_M".to_string(),
             family: "unknown".to_string(),

--- a/crates/ferric-cli/src/query.rs
+++ b/crates/ferric-cli/src/query.rs
@@ -3,8 +3,8 @@
 //!
 //! Executor boundary (plan C-009): `--mock` drives the loop on
 //! `futures_executor::block_on` (no tokio in the default build); the real
-//! backend constructs a tokio multi-thread runtime (mistral.rs client
-//! futures need ambient tokio).
+//! backend constructs a tokio multi-thread runtime (the OpenAI HTTP client's
+//! async futures need ambient tokio).
 
 use std::path::PathBuf;
 use std::process::ExitCode;
@@ -22,9 +22,9 @@ use ferric_provider::{Capabilities, Completion, MockProvider, Provider, Sampling
 use ferric_tools::{Registry, register_builtin_tools};
 use ferric_trace::{Event, JsonlSink};
 
+use crate::backend::BackendOpts;
 #[cfg(feature = "backend-openai")]
 use crate::backend::create_provider;
-use crate::backend::{BackendArg, BackendOpts};
 
 /// CLI spelling of `ActionProtocol`. `grammar` is the server-enforced
 /// constrained-JSON path (the thesis); `xml` is the unconstrained
@@ -248,7 +248,6 @@ pub struct QueryArgs {
 /// reuses the resulting `RunConfig` across every subsequent `tools/call`.
 pub(crate) struct RunConfigArgs {
     pub mock: bool,
-    pub backend: BackendArg,
     pub params_b: f32,
     pub quant: String,
     pub family: String,
@@ -301,10 +300,9 @@ pub(crate) fn build_run_config(a: &RunConfigArgs) -> RunConfig {
     // Capability seed for auto protocol selection (an explicit `--protocol`
     // always overrides it). The backend's own `capabilities()` is the source of
     // truth, but the provider is constructed later (in drive_real, or once at
-    // `ferric mcp` launch), so we mirror it from the chosen backend: the HTTP
-    // valve enforces a JSON-Schema constraint (→ ConstrainedJson); mistral.rs
-    // does neither — its constrained path hangs upstream (ADR-020) and it
-    // strips tools — so it lands on the honest TextXml fallback.
+    // `ferric mcp` launch), so we mirror the sole backend here: the OpenAI HTTP
+    // valve enforces a JSON-Schema constraint server-side (→ ConstrainedJson)
+    // and carries media.
     let caps = if a.mock {
         Capabilities {
             supports_native_tool_calls: true,
@@ -313,13 +311,11 @@ pub(crate) fn build_run_config(a: &RunConfigArgs) -> RunConfig {
             supports_media: false,
         }
     } else {
-        match a.backend {
-            BackendArg::Openai => Capabilities {
-                supports_native_tool_calls: true,
-                supports_constraint: true,
-                exposes_logits: false,
-                supports_media: true,
-            },
+        Capabilities {
+            supports_native_tool_calls: true,
+            supports_constraint: true,
+            exposes_logits: false,
+            supports_media: true,
         }
     };
     // Protocol is caps/override-driven (`select_protocol` ignores the policy), so
@@ -577,7 +573,6 @@ pub fn run_query(mut args: QueryArgs) -> ExitCode {
 
     let mut config = build_run_config(&RunConfigArgs {
         mock: args.mock,
-        backend: args.backend_opts.backend.unwrap_or(BackendArg::Openai),
         params_b: resolved_params_b,
         quant: resolved_quant,
         family: resolved_family,
@@ -1295,7 +1290,6 @@ mod tests {
             requested_skills: Vec::new(),
             allowed_skills: Vec::new(),
             mock: true,
-            backend: BackendArg::Openai,
             params_b: 8.0,
             quant: "Q4_K_M".to_string(),
             family: "unknown".to_string(),

--- a/crates/ferric-cli/src/query.rs
+++ b/crates/ferric-cli/src/query.rs
@@ -72,6 +72,34 @@ impl From<TierArg> for ferric_core::Tier {
     }
 }
 
+/// CLI spelling of the CaMeL sink action (ADR-080). A `ValueEnum` rather than a
+/// free-form string so an unrecognized value is **rejected at parse time**
+/// instead of silently collapsing to `requireapproval` — quietly defaulting a
+/// typo is the wrong failure mode for a security control. The canonical
+/// spellings (`requireapproval`/`deny`/`warn`) are unchanged; `require-approval`
+/// is accepted as an alias.
+#[derive(Debug, Clone, Copy, ValueEnum, PartialEq, Eq)]
+pub enum SinkActionArg {
+    /// Ask a human once per mutation (via `--accept-edits`); with no approver
+    /// available, deny. The default.
+    #[value(name = "requireapproval", alias = "require-approval")]
+    RequireApproval,
+    /// Block the mutation outright.
+    Deny,
+    /// Allow the mutation but warn on stderr.
+    Warn,
+}
+
+impl SinkActionArg {
+    pub(crate) fn into_policy(self) -> ferric_guard::SinkPolicy {
+        match self {
+            SinkActionArg::RequireApproval => ferric_guard::SinkPolicy::require_approval(),
+            SinkActionArg::Deny => ferric_guard::SinkPolicy::deny(),
+            SinkActionArg::Warn => ferric_guard::SinkPolicy::new(ferric_guard::SinkAction::Warn),
+        }
+    }
+}
+
 #[derive(Args)]
 pub struct QueryArgs {
     /// The task prompt. Required unless `--resume` is given (a pure
@@ -223,7 +251,6 @@ pub struct QueryArgs {
     #[arg(long)]
     pub allow_standard_runtime: bool,
 
-    /// The SinkAction for the CaMeL sink policy. Deny | RequireApproval | Warn.
     /// What to do with a MUTATION once this run has ingested untrusted content
     /// (ADR-080): `requireapproval` (default) | `deny` | `warn`.
     ///
@@ -231,8 +258,8 @@ pub struct QueryArgs {
     /// gated. `requireapproval` asks a human once per mutation (via
     /// `--accept-edits`); with no approver available there is nobody to ask, so
     /// it denies.
-    #[arg(long, default_value = "requireapproval")]
-    pub sink_action: String,
+    #[arg(long, value_enum, default_value = "requireapproval")]
+    pub sink_action: SinkActionArg,
 
     /// Accept-edits mode (ADR-070): pause before each mutating tool call
     /// (write/edit/delete/exec), show a preview, and require `y` to apply it.
@@ -767,11 +794,7 @@ pub fn run_query(mut args: QueryArgs) -> ExitCode {
         stream_sink,
         resume,
         provenance: ferric_guard::Provenance::Clean,
-        sink_policy: match args.sink_action.to_lowercase().as_str() {
-            "warn" => ferric_guard::SinkPolicy::new(ferric_guard::SinkAction::Warn),
-            "deny" => ferric_guard::SinkPolicy::deny(),
-            _ => ferric_guard::SinkPolicy::require_approval(),
-        },
+        sink_policy: args.sink_action.into_policy(),
         hooks: config.hooks.clone(),
         edit_approver: approver_ref,
     };
@@ -1206,6 +1229,50 @@ fn drive_real(
 mod tests {
     use super::*;
     use ferric_core::policy_for;
+
+    /// Each `--sink-action` spelling maps to the policy it names — the security
+    /// control must not drift from its label.
+    #[test]
+    fn sink_action_maps_to_the_named_policy() {
+        assert_eq!(
+            SinkActionArg::RequireApproval.into_policy(),
+            ferric_guard::SinkPolicy::require_approval()
+        );
+        assert_eq!(
+            SinkActionArg::Deny.into_policy(),
+            ferric_guard::SinkPolicy::deny()
+        );
+        assert_eq!(
+            SinkActionArg::Warn.into_policy(),
+            ferric_guard::SinkPolicy::new(ferric_guard::SinkAction::Warn)
+        );
+    }
+
+    /// The point of making this a `ValueEnum`: a typo is **rejected**, not
+    /// silently treated as `requireapproval` (which is what the old free-form
+    /// `String` match did). The canonical spellings and the `require-approval`
+    /// alias still parse.
+    #[test]
+    fn sink_action_accepts_known_spellings_and_rejects_typos() {
+        use clap::ValueEnum;
+        for ok in ["requireapproval", "require-approval"] {
+            assert_eq!(
+                SinkActionArg::from_str(ok, false),
+                Ok(SinkActionArg::RequireApproval),
+                "{ok} should parse"
+            );
+        }
+        assert_eq!(
+            SinkActionArg::from_str("deny", false),
+            Ok(SinkActionArg::Deny)
+        );
+        assert_eq!(
+            SinkActionArg::from_str("warn", false),
+            Ok(SinkActionArg::Warn)
+        );
+        // A near-miss for a security control must fail loudly, not default.
+        assert!(SinkActionArg::from_str("deni", false).is_err());
+    }
 
     /// T-3806: `Animus.md` folds in AFTER whichever base prompt already
     /// exists (composed or default), as a distinct, clearly-delimited block.

--- a/crates/ferric-cli/src/server.rs
+++ b/crates/ferric-cli/src/server.rs
@@ -577,9 +577,7 @@ fn doctor(workspace: &Path, args: &ServerUpArgs) -> ExitCode {
         Some(rf) if is_listening("127.0.0.1", rf.port) => {
             println!("[ok] server reachable at {}", rf.base_url);
             println!("     health: {}", health_url(rf.engine, &rf.base_url));
-            println!(
-                "     verify the constrained path: `ferric toolbench --backend openai --protocol grammar`"
-            );
+            println!("     verify the constrained path: `ferric bench ltd --protocol grammar`");
         }
         Some(rf) => println!("[warn] registered server {} is not reachable", rf.base_url),
         None => println!("[info] no server running — `ferric server up` to start one"),

--- a/crates/ferric-core/src/media.rs
+++ b/crates/ferric-core/src/media.rs
@@ -215,7 +215,7 @@ mod tests {
             decide_attachment(&img, &[], true),
             Attachment::Skip(_)
         ));
-        // declared, but a text-only backend (mistral.rs) → skip with a reason
+        // declared, but a text-only backend → skip with a reason
         assert!(matches!(
             decide_attachment(&img, &[Modality::Image], false),
             Attachment::Skip(_)

--- a/crates/ferric-loop/src/lib.rs
+++ b/crates/ferric-loop/src/lib.rs
@@ -8,7 +8,7 @@
 //!
 //! Executor-agnostic: no tokio here. Callers drive `run` on whatever
 //! executor suits their backend (futures-executor for mocks, a tokio
-//! runtime for mistral.rs).
+//! runtime for the OpenAI HTTP backend).
 
 mod backoff;
 mod compact;

--- a/crates/ferric-loop/src/protocol.rs
+++ b/crates/ferric-loop/src/protocol.rs
@@ -13,11 +13,12 @@ use ferric_provider::Capabilities;
 /// Else `TextXml`, the honest fallback: the model is prompted to emit
 /// `<tool_call>` XML and the loop regex-scrapes it, claiming no constraint.
 ///
-/// The in-process mistral.rs backend advertises neither capability (its
-/// constrained path hangs upstream — ADR-020), so it lands on `TextXml` and
-/// never hangs by default; the constrained thesis lives on the backend that
-/// can actually enforce it. `_policy` is retained for signature stability
-/// (selection is capability-driven, not model-size-driven).
+/// A backend advertising neither capability lands on `TextXml`, the honest
+/// fallback — the constrained thesis lives on the backend that can actually
+/// enforce it. (This was the in-process mistral.rs path, whose constrained
+/// decoding hung upstream — ADR-020/027; it has since been removed, but the
+/// fallback stays correct for any such backend.) `_policy` is retained for
+/// signature stability (selection is capability-driven, not model-size-driven).
 pub fn select_protocol(
     _policy: &RunPolicy,
     caps: &Capabilities,
@@ -78,7 +79,7 @@ mod tests {
 
     #[test]
     fn neither_selects_text_xml() {
-        // mistral.rs-shaped caps: neither constraint nor native → honest XML.
+        // A backend with neither constraint nor native tool calling → honest XML.
         assert_eq!(
             select_protocol(&nano(), &caps(false, false), None),
             ActionProtocol::TextXml

--- a/crates/ferric-provider/Cargo.toml
+++ b/crates/ferric-provider/Cargo.toml
@@ -30,11 +30,10 @@ ferric-tools = { workspace = true }
 ferric-trace = { workspace = true }
 futures-executor = { workspace = true }
 tempfile = { workspace = true }
-# Test-only: the grammar_probe diagnostic needs an ambient runtime to drive
-# the mistralrs client (matches query.rs). Dev-dep only — not in the default
-# library graph or the aarch64 check gate. `net`/`macros` (sprint 37, ADR-047):
-# the `backend-openai` streaming E2E test spins up a real
-# `tokio::net::TcpListener` fake server and uses `#[tokio::test]` — test-only,
-# NOT needed by `complete_streaming`'s production code path (it reads via
-# `Response::chunk()`, which needs no `stream` feature and no `tokio::net`).
+# Test-only tokio: the `backend-openai` streaming E2E test spins up a real
+# `tokio::net::TcpListener` fake server and uses `#[tokio::test]`. Dev-dep only
+# — not in the default library graph or the aarch64 check gate. `net`/`macros`
+# (sprint 37, ADR-047) are NOT needed by `complete_streaming`'s production path
+# (it reads via `Response::chunk()`, which needs no `stream` feature and no
+# `tokio::net`).
 tokio = { workspace = true, features = ["net", "macros", "io-util"] }

--- a/crates/ferric-research/src/sandbox.rs
+++ b/crates/ferric-research/src/sandbox.rs
@@ -51,6 +51,59 @@ pub enum NetworkPolicy {
     Unrestricted,
 }
 
+/// A host directory made visible inside the sandbox (ADR-101).
+///
+/// Until now the sandbox mounted **nothing** — correct for Ornstein, whose jobs
+/// fetch a URL and return text. Anything that must *act on a workspace* needs
+/// the workspace, and a mount is the point where a container stops being
+/// isolated by default: everything not mounted is unreachable, so what goes here
+/// is the entire filesystem authority the sandboxed process has.
+///
+/// `host` is deliberately an owned `PathBuf` resolved by the caller. A relative
+/// path handed to `docker -v` is interpreted by the *daemon*, not the client,
+/// which on Docker Desktop is a different filesystem namespace entirely.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WorkspaceMount {
+    /// Absolute host path to expose.
+    pub host: std::path::PathBuf,
+    /// Where it appears inside the container, and the working directory.
+    pub container: String,
+    /// Mount read-only. Default for anything that does not need to write.
+    pub read_only: bool,
+}
+
+impl WorkspaceMount {
+    /// A read-only mount at `/workspace` — the safe shape, so the *writable*
+    /// one has to be asked for by name.
+    pub fn read_only(host: impl Into<std::path::PathBuf>) -> Self {
+        Self {
+            host: host.into(),
+            container: "/workspace".to_string(),
+            read_only: true,
+        }
+    }
+
+    /// A writable mount. Named separately so a reviewer grepping for write
+    /// access into a sandbox finds every one.
+    pub fn writable(host: impl Into<std::path::PathBuf>) -> Self {
+        Self {
+            host: host.into(),
+            container: "/workspace".to_string(),
+            read_only: false,
+        }
+    }
+
+    /// The `-v host:container[:ro]` value.
+    fn volume_spec(&self) -> String {
+        let host = self.host.display().to_string();
+        if self.read_only {
+            format!("{host}:{}:ro", self.container)
+        } else {
+            format!("{host}:{}", self.container)
+        }
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct SandboxConfig {
     pub image: String,
@@ -58,6 +111,9 @@ pub struct SandboxConfig {
     /// fails closed, which is the correct direction for a security control.
     pub enforce_runsc: bool,
     pub network: NetworkPolicy,
+    /// The only host filesystem the sandboxed process can see. `None` — the
+    /// default — means it sees none of the host at all (ADR-101).
+    pub mount: Option<WorkspaceMount>,
 }
 
 impl Default for SandboxConfig {
@@ -67,6 +123,7 @@ impl Default for SandboxConfig {
             image: "alpine:latest".to_string(),
             enforce_runsc: true,
             network: NetworkPolicy::Denied,
+            mount: None,
         }
     }
 }
@@ -79,6 +136,7 @@ impl SandboxConfig {
             image: "alpine:latest".to_string(),
             enforce_runsc: false,
             network: NetworkPolicy::Unrestricted,
+            mount: None,
         }
     }
 }
@@ -178,6 +236,18 @@ pub fn docker_args(config: &SandboxConfig, cmd: &[&str]) -> Vec<String> {
     args.push("--security-opt".into());
     args.push("no-new-privileges".into());
 
+    // The mount is the sandbox's entire filesystem authority (ADR-101): with
+    // none, the host is unreachable; with one, exactly that subtree is reachable
+    // and nothing else. `--workdir` is set to the same place so a relative
+    // command behaves the way the caller means, rather than resolving against
+    // the image's default directory.
+    if let Some(mount) = &config.mount {
+        args.push("--volume".into());
+        args.push(mount.volume_spec());
+        args.push("--workdir".into());
+        args.push(mount.container.clone());
+    }
+
     if config.enforce_runsc {
         args.push("--runtime=runsc".into());
     }
@@ -230,6 +300,64 @@ mod tests {
             !joined.contains("--network bridge"),
             "default must not attach a bridge, got: {joined}"
         );
+    }
+
+    // --- ADR-101: the mount is the sandbox's filesystem authority ---
+
+    /// The property that makes a mount safe to add at all: without one, the
+    /// sandboxed process is handed no host filesystem whatsoever. If this ever
+    /// stops holding, every other guarantee here is downstream of an accident.
+    #[test]
+    fn no_mount_means_no_host_filesystem_reaches_the_sandbox() {
+        let joined = args_of(&SandboxConfig::default()).join(" ");
+        assert!(!joined.contains("--volume"), "got: {joined}");
+        assert!(!joined.contains("--workdir"), "got: {joined}");
+    }
+
+    #[test]
+    fn a_read_only_mount_is_marked_ro_and_sets_the_workdir() {
+        let config = SandboxConfig {
+            mount: Some(WorkspaceMount::read_only("/host/ws")),
+            ..SandboxConfig::default()
+        };
+        let args = args_of(&config);
+        let joined = args.join(" ");
+        assert!(
+            joined.contains("--volume /host/ws:/workspace:ro"),
+            "{joined}"
+        );
+        assert!(joined.contains("--workdir /workspace"), "{joined}");
+    }
+
+    /// Writable is a separate constructor precisely so it cannot be reached by
+    /// leaving a field unset — the same reasoning as `NetworkPolicy`.
+    #[test]
+    fn a_writable_mount_omits_ro_and_must_be_asked_for_by_name() {
+        let config = SandboxConfig {
+            mount: Some(WorkspaceMount::writable("/host/ws")),
+            ..SandboxConfig::default()
+        };
+        let joined = args_of(&config).join(" ");
+        assert!(joined.contains("--volume /host/ws:/workspace "), "{joined}");
+        assert!(
+            !joined.contains(":ro"),
+            "writable must not be marked ro: {joined}"
+        );
+    }
+
+    /// Adding a mount must not quietly relax anything else. The mount widens
+    /// filesystem reach and *only* that.
+    #[test]
+    fn mounting_does_not_relax_the_network_or_capabilities() {
+        let config = SandboxConfig {
+            mount: Some(WorkspaceMount::writable("/host/ws")),
+            ..SandboxConfig::default()
+        };
+        let joined = args_of(&config).join(" ");
+        assert!(joined.contains("--network none"), "{joined}");
+        assert!(joined.contains("--cap-drop=ALL"), "{joined}");
+        assert!(joined.contains("no-new-privileges"), "{joined}");
+        assert!(joined.contains("--runtime=runsc"), "{joined}");
     }
 
     /// The gVisor runtime is part of the airlock, so it is on by default too.

--- a/crates/ferric-research/tests/sandbox_live.rs
+++ b/crates/ferric-research/tests/sandbox_live.rs
@@ -296,6 +296,22 @@ fn workspace_and_outsider() -> (tempfile::TempDir, std::path::PathBuf) {
     let dir = tempfile::tempdir().expect("tempdir");
     let ws = dir.path().join("ws");
     std::fs::create_dir_all(&ws).expect("mkdir ws");
+    // The sandbox drops CAP_DAC_OVERRIDE (`--cap-drop=ALL`) and runs the
+    // container as root, so on Linux container-root is subject to ordinary DAC
+    // as "other". A freshly created dir is 0755 owned by the host user, which
+    // lets container-root read/traverse it (the read tests) but NOT create a
+    // file in it — so `a_writable_mount_persists_to_the_host` failed on native
+    // Linux CI while passing on Docker Desktop, whose file-sharing layer masks
+    // host DAC. Make the workspace world-writable so a *writable* mount can
+    // actually be written by the sandboxed process, which is the property under
+    // test. For a read-only mount this changes nothing: `:ro` still refuses the
+    // write — and now provably via the mount, not incidentally via DAC.
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&ws, std::fs::Permissions::from_mode(0o777))
+            .expect("chmod workspace 0777");
+    }
     std::fs::write(ws.join("inside.txt"), "workspace-content").expect("write inside");
     // A sibling of the workspace, deliberately not mounted.
     std::fs::write(dir.path().join("outside.txt"), "HOST-SECRET").expect("write outside");

--- a/crates/ferric-research/tests/sandbox_live.rs
+++ b/crates/ferric-research/tests/sandbox_live.rs
@@ -10,7 +10,9 @@
 //! people to ignore it. The skip is loud in the output so a green run is not
 //! mistaken for a validated one.
 
-use ferric_research::sandbox::{NetworkPolicy, SandboxConfig, check_available, run_in_sandbox};
+use ferric_research::sandbox::{
+    NetworkPolicy, SandboxConfig, WorkspaceMount, check_available, run_in_sandbox,
+};
 
 /// `true` when the daemon is reachable; prints a visible skip notice otherwise.
 fn docker_ready(test: &str) -> bool {
@@ -283,5 +285,120 @@ fn the_airlock_enforces_the_allowlist_and_cannot_be_bypassed() {
         bypass.is_err(),
         "unsetting the proxy env MUST NOT restore egress — that was the whole \
          defect in the old bridge-based policy: {bypass:?}"
+    );
+}
+
+// --- ADR-101: the mount is the sandbox's entire filesystem authority ---
+
+/// Build a temp workspace with a marker file, plus a sibling "secret" directory
+/// OUTSIDE it standing in for everything on the host the agent must not reach.
+fn workspace_and_outsider() -> (tempfile::TempDir, std::path::PathBuf) {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let ws = dir.path().join("ws");
+    std::fs::create_dir_all(&ws).expect("mkdir ws");
+    std::fs::write(ws.join("inside.txt"), "workspace-content").expect("write inside");
+    // A sibling of the workspace, deliberately not mounted.
+    std::fs::write(dir.path().join("outside.txt"), "HOST-SECRET").expect("write outside");
+    (dir, ws)
+}
+
+/// The positive half: a mounted workspace is genuinely readable. Without this,
+/// the negative test below could pass because the container reads *nothing*,
+/// which would prove the mount broken rather than the confinement working.
+#[test]
+fn a_mounted_workspace_is_readable_inside_the_sandbox() {
+    if !docker_ready("a_mounted_workspace_is_readable_inside_the_sandbox") {
+        return;
+    }
+    let (_dir, ws) = workspace_and_outsider();
+    let config = SandboxConfig {
+        network: NetworkPolicy::Denied,
+        enforce_runsc: false,
+        mount: Some(WorkspaceMount::read_only(&ws)),
+        ..SandboxConfig::default()
+    };
+    let out = run(&config, &["cat", "inside.txt"]).expect("mounted file should be readable");
+    assert!(out.contains("workspace-content"), "got: {out}");
+}
+
+/// The security property: everything not mounted is unreachable. This is the
+/// assertion that makes a sandboxed `shell_exec` worth building — on the host
+/// today, the same read succeeds.
+#[test]
+fn the_host_outside_the_mount_is_unreachable() {
+    if !docker_ready("the_host_outside_the_mount_is_unreachable") {
+        return;
+    }
+    let (dir, ws) = workspace_and_outsider();
+    let outsider = dir.path().join("outside.txt");
+    // Sanity: the file really exists on the host and really holds the marker.
+    // Without this the container's failure to read it proves nothing.
+    assert_eq!(
+        std::fs::read_to_string(&outsider).expect("host read"),
+        "HOST-SECRET"
+    );
+
+    let config = SandboxConfig {
+        network: NetworkPolicy::Denied,
+        enforce_runsc: false,
+        mount: Some(WorkspaceMount::read_only(&ws)),
+        ..SandboxConfig::default()
+    };
+    // Reach for it by absolute host path AND by traversal out of the workdir.
+    for probe in [outsider.display().to_string(), "../outside.txt".to_string()] {
+        let result = run(&config, &["cat", &probe]);
+        assert_failed_because(
+            &result,
+            &["No such file or directory", "can't open"],
+            &format!("the sandbox must not read {probe}"),
+        );
+    }
+}
+
+/// A read-only mount must actually refuse writes — otherwise `read_only` is a
+/// label rather than a control.
+#[test]
+fn a_read_only_mount_refuses_writes() {
+    if !docker_ready("a_read_only_mount_refuses_writes") {
+        return;
+    }
+    let (_dir, ws) = workspace_and_outsider();
+    let config = SandboxConfig {
+        network: NetworkPolicy::Denied,
+        enforce_runsc: false,
+        mount: Some(WorkspaceMount::read_only(&ws)),
+        ..SandboxConfig::default()
+    };
+    let result = run(&config, &["sh", "-c", "echo mutated > inside.txt"]);
+    assert_failed_because(
+        &result,
+        &["Read-only file system", "read-only"],
+        "a read-only mount must reject a write",
+    );
+    // And the host file is untouched — the control worked, not just errored.
+    assert_eq!(
+        std::fs::read_to_string(ws.join("inside.txt")).expect("host read"),
+        "workspace-content"
+    );
+}
+
+/// The writable case, which a sandboxed `shell_exec` would need: the write
+/// lands, and it lands **on the host**, so work done in the sandbox is real.
+#[test]
+fn a_writable_mount_persists_to_the_host() {
+    if !docker_ready("a_writable_mount_persists_to_the_host") {
+        return;
+    }
+    let (_dir, ws) = workspace_and_outsider();
+    let config = SandboxConfig {
+        network: NetworkPolicy::Denied,
+        enforce_runsc: false,
+        mount: Some(WorkspaceMount::writable(&ws)),
+        ..SandboxConfig::default()
+    };
+    run(&config, &["sh", "-c", "echo from-sandbox > created.txt"]).expect("write should succeed");
+    assert_eq!(
+        std::fs::read_to_string(ws.join("created.txt")).expect("host read"),
+        "from-sandbox\n"
     );
 }

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -171,7 +171,7 @@ Bound to loopback by default. Requires the `backend-openai` build. Routes:
 ## `ferric dream` 🔵 — memory consolidation
 
 ```
-ferric dream [--recent-traces <N>] [--memory-file <PATH>] [backend/model]
+ferric dream [--recent-traces <N>] [--memory-file <PATH>] [--model <NAME>] [--api-base <URL>]
 ```
 
 Parses recent `.ferric/traces` into a synthesized `MEMORY.md` (default
@@ -197,6 +197,18 @@ agent's memory resets there. Workspace root is automatically resolved from the t
 ferric trace cat <FILE>        # render a JSONL trace as a readable log
 ferric trace verify <GOLDEN>   # replay with the mock to detect execution drift
 ```
+
+---
+
+## `ferric skills` — inspect installed skills (offline)
+
+```
+ferric skills list [--workspace <DIR>]   # list skills in .ferric/skills/ and how each authorizes
+```
+
+Skills are per-workspace instruction sets under `.ferric/skills/`. `list` shows
+each one and whether it is standing-authorized (via `allowed_skills` in config)
+or must be named per run with `ferric query --skill <name>` (ADR-091).
 
 ---
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -36,7 +36,7 @@ Runs one workspace-scoped, constrained agent loop. `PROMPT` is required unless
 | `--accept-edits` | pause before every mutating (`Write`/`Execute`) tool call and preview it; approve/reject from stdin (y/N) before it touches disk |
 | `--resume <TRACE>` | continue an interrupted, incomplete session |
 | `--research <QUERY>` | run the Ornstein research phase first (quarantined) |
-| `--sink-action deny\|warn\|requireapproval` | CaMeL sink policy for tainted data (default deny) |
+| `--sink-action requireapproval\|deny\|warn` | CaMeL sink policy for tainted data (default requireapproval) |
 
 ---
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -21,8 +21,7 @@ Runs one workspace-scoped, constrained agent loop. `PROMPT` is required unless
 |---|---|
 | `--workspace <DIR>` | containment boundary (default: current dir) |
 | `--mock` | use the built-in scripted model — **no engine needed** |
-| `--backend openai` | inference backend (default) |
-| `--model <NAME>` | model id (required for a real openai backend) |
+| `--model <NAME>` | model id (required for a real backend) |
 | `--api-base <URL>` | server URL (default: the running `ferric server`, else `http://localhost:1234/v1`) |
 | `--api-key <KEY>` | API key, if your server needs one |
 | `--params-b <N>` · `--quant <Q>` · `--family <F>` · `--ctx <N>` | model profile → run policy (defaults 1.2 / Q4_K_M / unknown / 4096) |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -22,8 +22,7 @@ A TOML file at `<workspace>/.ferric/config.toml`. Every field is optional; set
 only what you want to stop repeating on the command line.
 
 ```toml
-# Inference backend + model
-backend     = "openai"          # currently the one backend
+# Model + inference server (the OpenAI-compatible HTTP valve is the only backend)
 model       = "qwen2.5-coder:7b"
 api_base    = "http://localhost:8080/v1"   # omit to auto-discover `ferric server`
 api_key     = ""                # if your server needs one

--- a/docs/demo-guide.md
+++ b/docs/demo-guide.md
@@ -313,16 +313,16 @@ Don't take a small model's tool-calling on faith — measure it.
 
 ```sh
 # Single-turn fire rate + failure taxonomy + verdict band:
-ferric bench ltd --backend openai --model <name> --protocol grammar --iterations 20 --report report.md
+ferric bench ltd --model <name> --protocol grammar --iterations 20 --report report.md
 
 # The full L0–L6 capability ladder -> a measured_level:
-ferric bench full --backend openai --model <name>
+ferric bench full --model <name>
 
 # Calibrate a fleet into one leaderboard (pick the smallest still-solid model):
-ferric bench ltd --backend openai --models qwen2.5-coder:7b,llama3.1:8b,llama3.2:1b --protocol grammar --report fleet.md
+ferric bench ltd --models qwen2.5-coder:7b,llama3.1:8b,llama3.2:1b --protocol grammar --report fleet.md
 
 # Calibrate the rings a model can reliably drive:
-ferric bench ltd --backend openai --model <name> --calibrate-rings --profile-dir benchmarks
+ferric bench ltd --model <name> --calibrate-rings --profile-dir benchmarks
 ```
 
 `bench full --mock` runs the ladder offline (against the scripted model) to

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -37,8 +37,22 @@ cd Animus_Ferric
 cargo build --release -p ferric-cli --features backend-openai
 ```
 
-The binary lands at `target/release/ferric` (`ferric.exe` on Windows). Put it on
-your `PATH`, or call it by path. The examples below assume `ferric` is on `PATH`.
+The binary lands at `target/release/ferric` (`ferric.exe` on Windows) — call it
+by path, or put it on your `PATH`. To install it on your `PATH` the same way on
+Windows, Linux, and macOS, use `cargo install`, which builds in release and
+copies the binary into `~/.cargo/bin` (rustup already adds that to your `PATH`):
+
+```sh
+cargo install --path crates/ferric-cli --features backend-openai --force
+# wrappers that do exactly this:
+#   Linux/macOS:  ./tools/install.sh
+#   Windows:      .\tools\install.ps1
+```
+
+Re-run that **after every `git pull` or source change**: a plain `cargo build`
+updates `target/release/` but *not* the copy on your `PATH`, so an installed
+`ferric` can silently lag the code. `--force` re-installs despite the unchanged
+`0.1.0` version. The examples below assume `ferric` is on `PATH`.
 
 > **Built with no backend feature** (`cargo build -p ferric-cli`), only the
 > offline tooling works — `trace`, `launch`, `icm init`/`plan`, `cron add`/`list`,

--- a/docs/llama-cpp.md
+++ b/docs/llama-cpp.md
@@ -52,11 +52,11 @@ Two ways:
 ```sh
 # (a) let Ferric launch + manage it (writes .ferric/server.json so other commands auto-discover it):
 ferric server up --engine llama-server --model /path/to/model.gguf [--mmproj mmproj.gguf] [--ctx 8192]
-ferric query  --backend openai --protocol grammar "…your task…"     # auto-discovers the server
+ferric query  --protocol grammar "…your task…"     # auto-discovers the server
 ferric server down
 
 # (b) or point Ferric at a server you started yourself:
-ferric query --backend openai --api-base http://127.0.0.1:8080/v1 --model any-label --protocol grammar "…"
+ferric query --api-base http://127.0.0.1:8080/v1 --model any-label --protocol grammar "…"
 ```
 
 `--engine ollama` remains available if you prefer ollama for model management.
@@ -72,7 +72,7 @@ models are text-only, so there's no blob to reuse for vision):
 #   huggingface.co/ggml-org/SmolVLM-500M-Instruct-GGUF
 llama-server -m SmolVLM-500M-Instruct-Q8_0.gguf --mmproj mmproj-SmolVLM-500M-Instruct-Q8_0.gguf -c 4096 --port 8080
 
-ferric query --backend openai --api-base http://127.0.0.1:8080/v1 \
+ferric query --api-base http://127.0.0.1:8080/v1 \
   --file pic.png --modality image "what is in this image?"
 ```
 
@@ -93,11 +93,11 @@ no workaround needed. Official, ungated GGUF + mmproj:
 llama-server -m gemma-4-E4B_q4_0-it.gguf --mmproj gemma-4-E4B-it-mmproj.gguf -c 8192 --port 8080
 
 # vision:
-ferric query --backend openai --api-base http://127.0.0.1:8080/v1 \
+ferric query --api-base http://127.0.0.1:8080/v1 \
   --file pic.png --modality image "describe this image, then call task_complete"
 
 # audio (Gemma 4's mmproj is a unified vision+audio projector — same server):
-ferric query --backend openai --api-base http://127.0.0.1:8080/v1 \
+ferric query --api-base http://127.0.0.1:8080/v1 \
   --file speech.wav --modality audio "transcribe this audio, then call task_complete"
 ```
 

--- a/docs/multimodal.md
+++ b/docs/multimodal.md
@@ -9,7 +9,7 @@ ferric query --file src/lib.rs --file notes.md "explain what this code does"
 
 # Media files (image/audio/video) attach as content parts — needs a model that
 # can read them, declared with --modality:
-ferric query --backend openai --file diagram.png --modality image "describe the diagram"
+ferric query --file diagram.png --modality image "describe the diagram"
 ```
 
 ## How a file is routed
@@ -28,7 +28,7 @@ Each `--file` is classified by extension and then gated — pure logic in
 **Gating (ADR-006 / ADR-022).** Media is attached only when **(a)** you declared
 its modality with `--modality` (explicit config — Ferric never sniffs a model's
 abilities) **and (b)** the backend can carry media (`supports_media` — true for
-the OpenAI valve, false for the in-process mistral.rs path). If either is
+the OpenAI valve, false for a text-only backend). If either is
 missing, the file is **skipped with a reason printed to stderr** — never sent
 silently and never a hard failure. So `--file photo.png` with no `--modality`
 runs fine, text-only, and tells you why the image wasn't sent.
@@ -41,11 +41,11 @@ server and model behind the OpenAI valve — e.g. Gemma 3n (`gemma-4-e4b`):
 ```sh
 # llama.cpp with a projector (the surest path; supports image/audio):
 ferric server up --engine llama-server --model gemma-3n-E4B.gguf --mmproj mmproj.gguf
-ferric query --backend openai --file clip.wav --modality audio "transcribe this"
+ferric query --file clip.wav --modality audio "transcribe this"
 ferric server down
 ```
 
-(Ollama can serve some vision models too; pull one and point `--backend openai`
+(Ollama can serve some vision models too; pull one and point `--api-base`
 at it. Audio/video coverage is widest on llama.cpp's libmtmd.)
 
 ## Notes

--- a/docs/testbench.md
+++ b/docs/testbench.md
@@ -36,10 +36,10 @@ ferric server down      # stops it and clears the runfile
 ## 2. Run the diagnostic toolbench
 
 ```sh
-ferric bench ltd --backend openai --model <name> --protocol grammar --iterations 20 --report report.md
+ferric bench ltd --model <name> --protocol grammar --iterations 20 --report report.md
 ```
 
-- `--backend openai` with no `--api-base` auto-discovers the server from the runfile.
+- With no `--api-base`, the backend auto-discovers the server from the runfile.
 - `--protocol grammar` exercises the **constrained** path (the server enforces a
   JSON-Schema over the action space). Use `--protocol native` or `xml` to compare
   the unconstrained paths.
@@ -73,13 +73,13 @@ small models — that's the whole point of harness-owned decoding.
 ## 4. Calibrate the whole fleet at once
 
 Rather than dialing one model down by hand, sweep a list in one shot with
-`--models` (comma-separated — ollama model names, or GGUF files for the mistral
-backend). Each model is benched in turn and the results collapse into a single
+`--models` (comma-separated ollama / llama-server model names). Each model is
+benched in turn and the results collapse into a single
 **leaderboard**, sorted best→worst:
 
 ```sh
 # Every model shares the one running ollama server, so this is cheap:
-ferric bench ltd --backend openai \
+ferric bench ltd \
   --models qwen2.5-coder:7b,llama3.1:8b,qwen2.5-coder:1.5b \
   --protocol grammar --iterations 20 --report fleet.md
 ```
@@ -107,7 +107,7 @@ as a model proves itself). `--calibrate-rings` benches a model **ring by ring**
 and tells you the largest ring it reliably drives — the recommended `--max-ring`:
 
 ```sh
-ferric bench ltd --backend openai --models qwen2.5-coder:7b,llama3.2:1b \
+ferric bench ltd --models qwen2.5-coder:7b,llama3.2:1b \
   --protocol grammar --iterations 20 --calibrate-rings --report calib.md
 ```
 
@@ -140,11 +140,11 @@ tier (`measured_level`) and ring (`calibrated_ring`) — no manual `--max-ring`:
 
 ```sh
 # 1. Prove the model once — writes calibrated_ring into benchmarks/model_profiles.json
-ferric toolbench --backend openai --models llama3.2:1b --protocol grammar \
+ferric bench ltd --models llama3.2:1b --protocol grammar \
   --calibrate-rings --profile-dir benchmarks
 
 # 2. Every later query auto-applies it (the trace shows the capped ring)
-ferric query --backend openai --model llama3.2:1b "refactor this module"
+ferric query --model llama3.2:1b "refactor this module"
 ```
 
 `measured_level` *raises* the tier (capability earned); `calibrated_ring` *caps*
@@ -160,7 +160,7 @@ The toolbench measures whether a model fires the *right single tool call*.
 `measured_level` = the highest level it *completes* end-to-end:
 
 ```sh
-ferric bench full --backend openai --api-base http://localhost:11434/v1 \
+ferric bench full --api-base http://localhost:11434/v1 \
   --model qwen2.5-coder:7b --params-b 7 --protocol grammar
 ```
 
@@ -173,10 +173,10 @@ calibrated qwen2.5-coder:7b: measured_level 6 (Small -> Large)
 
 It writes `measured_level` into `benchmarks/model_profiles.json`, so a later
 `ferric query --profile-dir benchmarks` auto-runs the model at its *earned* tier
-(§5's read-back, now with full-loop data). `--backend openai` targets ollama or a
-`ferric server`; `--backend mistral` uses a local GGUF (text-only — its constrained
-path hangs upstream); `--mock` is the CI self-test. This is the end-to-end check
-that the constrained loop *completes tasks*, not just that it emits tool calls.
+(§5's read-back, now with full-loop data). The real backend (`--model`/
+`--api-base`) targets ollama or a `ferric server`; `--mock` is the CI self-test.
+This is the end-to-end check that the constrained loop *completes tasks*, not
+just that it emits tool calls.
 
 **Fleet sweep:** `--models qwen2.5-coder:7b,llama3.1:8b,llama3.2:1b` runs the whole
 ladder for each model and prints an **agentic capability leaderboard**

--- a/docs/testbench.md
+++ b/docs/testbench.md
@@ -33,7 +33,7 @@ ferric server doctor    # checks the engine binary + model are present
 ferric server down      # stops it and clears the runfile
 ```
 
-## 2. Run the diagnostic toolbench
+## 2. Run the diagnostic bench (`ferric bench ltd`)
 
 ```sh
 ferric bench ltd --model <name> --protocol grammar --iterations 20 --report report.md
@@ -154,7 +154,7 @@ read-back is a safe no-op until you've actually measured the model.
 
 ## 6. The full agentic loop — `ferric bench full` (L0–L6)
 
-The toolbench measures whether a model fires the *right single tool call*.
+`ferric bench ltd` measures whether a model fires the *right single tool call*.
 `ferric bench full` runs the **whole multi-turn loop** against a ladder of real tasks
 (L0 single readonly call → L6 a full todo app), and sets the model's
 `measured_level` = the highest level it *completes* end-to-end:

--- a/tools/install.ps1
+++ b/tools/install.ps1
@@ -1,0 +1,44 @@
+#!/usr/bin/env pwsh
+# Install the `ferric` binary onto your PATH (Windows / PowerShell).
+#
+# `cargo install` builds in release AND copies the binary into
+# %USERPROFILE%\.cargo\bin, which rustup already added to your PATH — so this is
+# the one step that both builds and puts `ferric` on your PATH. It is identical
+# in spirit to tools/install.sh for Linux/macOS.
+#
+# Re-run this after every `git pull` or source change. A plain
+# `cargo build --release` refreshes target\release\ but NOT the copy on your
+# PATH, so the `ferric` you invoke can silently lag the code (this is how a stale
+# binary still offering a removed flag sneaks in). `--force` re-installs even when
+# the version string is unchanged, which it always is here (0.1.0).
+#
+# Usage:
+#   .\tools\install.ps1                 # default: --features backend-openai
+#   .\tools\install.ps1 -Features ""    # trace/offline tooling only, no backend
+param(
+    [string]$Features = "backend-openai"
+)
+$ErrorActionPreference = "Stop"
+
+$repo = Split-Path -Parent $PSScriptRoot
+$crate = Join-Path $repo "crates/ferric-cli"
+
+$featureArgs = @()
+if ($Features -and $Features.Trim() -ne "") {
+    $featureArgs = @("--features", $Features)
+    Write-Host "Installing ferric (--features $Features) from $repo ..." -ForegroundColor Cyan
+} else {
+    Write-Host "Installing ferric (no backend feature) from $repo ..." -ForegroundColor Cyan
+}
+
+cargo install --path $crate @featureArgs --force
+if ($LASTEXITCODE -ne 0) { throw "cargo install failed (exit $LASTEXITCODE)" }
+
+$bin = Join-Path $env:USERPROFILE ".cargo\bin\ferric.exe"
+Write-Host "`nInstalled:" -ForegroundColor Green
+& $bin --version
+Write-Host "Location: $bin"
+
+if (-not (Get-Command ferric -ErrorAction SilentlyContinue)) {
+    Write-Warning "'$env:USERPROFILE\.cargo\bin' is not on your PATH. Add it (rustup normally does this) so 'ferric' resolves."
+}

--- a/tools/install.sh
+++ b/tools/install.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Install the `ferric` binary onto your PATH (Linux / macOS).
+#
+# `cargo install` builds in release AND copies the binary into ~/.cargo/bin,
+# which rustup already added to your PATH — so this is the one step that both
+# builds and puts `ferric` on your PATH. It mirrors tools/install.ps1 for Windows.
+#
+# Re-run this after every `git pull` or source change. A plain
+# `cargo build --release` refreshes target/release/ but NOT the copy on your
+# PATH, so the `ferric` you invoke can silently lag the code (this is how a stale
+# binary still offering a removed flag sneaks in). `--force` re-installs even when
+# the version string is unchanged, which it always is here (0.1.0).
+#
+# Usage:
+#   ./tools/install.sh                  # default: --features backend-openai
+#   ./tools/install.sh ""               # trace/offline tooling only, no backend
+set -euo pipefail
+
+FEATURES="${1-backend-openai}"
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CRATE="${REPO}/crates/ferric-cli"
+
+if [ -n "${FEATURES}" ]; then
+    echo "Installing ferric (--features ${FEATURES}) from ${REPO} ..."
+    cargo install --path "${CRATE}" --features "${FEATURES}" --force
+else
+    echo "Installing ferric (no backend feature) from ${REPO} ..."
+    cargo install --path "${CRATE}" --force
+fi
+
+BIN="${CARGO_HOME:-${HOME}/.cargo}/bin/ferric"
+echo
+echo "Installed:"
+"${BIN}" --version
+echo "Location: ${BIN}"
+
+if ! command -v ferric >/dev/null 2>&1; then
+    echo "WARNING: '${CARGO_HOME:-${HOME}/.cargo}/bin' is not on your PATH. Add it (rustup normally does this) so 'ferric' resolves." >&2
+fi

--- a/tools/run_benchmarks.ps1
+++ b/tools/run_benchmarks.ps1
@@ -9,8 +9,8 @@ param (
     [string]$LlamaGguf,
     [string]$OpenAiModel = "Llama-3.2-1B-Instruct",
     # Fleet calibration: ollama models to sweep into one leaderboard (must be
-    # `ollama pull`-ed). For a GGUF fleet instead, sweep `--backend mistral`
-    # with `--models file1.gguf,file2.gguf`.
+    # `ollama pull`-ed). For a llama-server fleet instead, point `--api-base` at
+    # it and pass local model ids in `--models`.
     [string]$OllamaFleet = "qwen2.5-coder:7b,llama3.1:8b"
 )
 
@@ -30,25 +30,25 @@ $Ferric = ".\target\release\ferric.exe"
 Write-Host "`nOpenAI valve (ConstrainedJson) via ferric server..." -ForegroundColor Cyan
 & $Ferric server up --engine llama-server --model $LlamaGguf
 & $Ferric server status
-& $Ferric bench ltd --backend openai --model $OpenAiModel --protocol grammar --iterations $Iterations --report toolbench_openai.md
+& $Ferric bench ltd --model $OpenAiModel --protocol grammar --iterations $Iterations --report toolbench_openai.md
 & $Ferric server down
 
 # 3. Fleet calibration across installed ollama models — one leaderboard, sorted
 # best->worst, so you can pick the smallest model that's still "solid". Targets a
 # running ollama directly (default :11434); skipped silently if ollama isn't up.
 Write-Host "`nFleet calibration (ollama) — $OllamaFleet ..." -ForegroundColor Cyan
-& $Ferric bench ltd --backend openai --api-base "http://localhost:11434/v1" --models $OllamaFleet --protocol grammar --iterations $Iterations --report toolbench_fleet.md
+& $Ferric bench ltd --api-base "http://localhost:11434/v1" --models $OllamaFleet --protocol grammar --iterations $Iterations --report toolbench_fleet.md
 
 # 4. Ring calibration — for each ollama model, sweep rings 0,1,... and report the
 # highest ring it reliably drives (the recommended --max-ring).
 Write-Host "`nRing calibration (ollama) — $OllamaFleet ..." -ForegroundColor Cyan
-& $Ferric bench ltd --backend openai --api-base "http://localhost:11434/v1" --models $OllamaFleet --protocol grammar --iterations $Iterations --calibrate-rings --report toolbench_calib.md
+& $Ferric bench ltd --api-base "http://localhost:11434/v1" --models $OllamaFleet --protocol grammar --iterations $Iterations --calibrate-rings --report toolbench_calib.md
 
 # 5. Full agentic loop (L0-L6) across the fleet — multi-turn task completion, not
 # just single tool calls. Writes each model's measured_level to
 # benchmarks/model_profiles.json (which `ferric query --profile-dir benchmarks`
 # auto-applies) and prints an agentic capability leaderboard.
 Write-Host "`nFull agentic loop L0-L6 fleet (ollama) — $OllamaFleet ..." -ForegroundColor Cyan
-& $Ferric bench full --backend openai --api-base "http://localhost:11434/v1" --models $OllamaFleet --params-b 7 --protocol grammar --results-dir benchmarks
+& $Ferric bench full --api-base "http://localhost:11434/v1" --models $OllamaFleet --params-b 7 --protocol grammar --results-dir benchmarks
 
-Write-Host "`nReports: toolbench_mistral.md / toolbench_openai.md / toolbench_fleet.md / toolbench_calib.md (+ .jsonl); benchmarks/model_profiles.json (measured_level). Read the verdict bands + the recommended --max-ring." -ForegroundColor Green
+Write-Host "`nReports: toolbench_openai.md / toolbench_fleet.md / toolbench_calib.md (+ .jsonl); benchmarks/model_profiles.json (measured_level). Read the verdict bands + the recommended --max-ring." -ForegroundColor Green


### PR DESCRIPTION
Two independent changes on `dev`:

## 1. WorkspaceMount for the research sandbox (ADR-101) — `ea3c6d9`

The sandbox mounted nothing (correct for Ornstein's fetch-a-URL jobs, but no way to act on a workspace). `WorkspaceMount` exposes exactly one host subtree into the container — **read-only by default**, writable only via an explicitly-named constructor — as `-v host:/workspace[:ro]` with `--workdir` pinned to the mount. With no mount, the host filesystem stays entirely unreachable.

- Unit tests: arg-building + that a mount relaxes neither the network nor the dropped capabilities.
- Docker-gated live tests: a mounted workspace is readable, the host **outside** it is unreachable (absolute path and `../` traversal), read-only refuses writes, and a writable mount persists to the host.

## 2. mistralrs cleanup + `--backend` removal + PATH install — `e8b9c8c`

The in-process mistral.rs backend is gone (ADR-027), leaving stale references and a single-valued selector.

- **Scrubbed** 8 stale `mistral.rs`/`mistralrs` comments and removed **dead code** in the bench runner (`ModelArgs`, `Invocation.model`, and the `query_args` arm that emitted `--model-dir`/`--model-file` flags `query` no longer accepts — always `None` at both call sites, so broken-if-used).
- **Removed `--backend` / `BackendArg` entirely** across 9 CLI files: the flag, the enum, the `Config.backend` field, the single-arm matches, and the bench runner's subprocess push. Only the OpenAI HTTP valve remains, so the selector was pure ceremony; a second variant re-enters trivially. **Old `backend = "openai"` configs still parse** (the now-unknown key is ignored) — proven by a repurposed backward-compat test.
- **Fixed docs** that referenced `--backend openai`/`mistral` in copy-pasteable examples (`testbench`, `demo-guide`, `llama-cpp`, `multimodal`, `commands`, and `run_benchmarks.ps1` — the script actually invoked it 4×) plus a stale `ferric toolbench` command name.
- **Documented getting `ferric` onto your PATH** cross-platform — the `cargo install` vs `cargo build` drift trap that left a months-old binary still offering the removed `--backend` flag — and added `tools/install.ps1` / `tools/install.sh` wrappers.

## 3. Validate `--sink-action` as an enum — `0c60b30`

`--sink-action` (the CaMeL sink policy, ADR-080) took a raw `String` and lowercased-matched it, so a typo like `deni` silently became `requireapproval` rather than erroring — the wrong failure mode for a security control. It's now a `SinkActionArg` `ValueEnum`: clap **rejects** unknown values at parse time and lists the valid ones. Canonical spellings (`requireapproval`/`deny`/`warn`) are unchanged and `require-approval` is accepted as an alias, so nothing breaks. Also fixes `docs/commands.md`, which wrongly listed the default as `deny` (it is and remains `requireapproval`).

## 4. Documentation caught up — `9c16421`

Follow-on docs for the CLI changes above: dropped `--backend openai` from the two README `bench ltd` examples and corrected three `toolbench` → `bench` prose references; removed the stale `backend = "openai"` key from `configuration.md`; named `ferric bench ltd` in `testbench.md`; fixed the `dream` usage line and added the missing `ferric skills` section in `commands.md`. (The docs `mdBook` restructure is a separate change, not in this PR.)

## Verification

- `cargo clippy --workspace --all-targets`: **0 warnings**
- Tests: **593** default + **185** `backend-openai` passing (+ 2 new `--sink-action` tests)
- Both feature paths build; the reinstalled binary rejects `--backend` and rejects an invalid `--sink-action`

🤖 Generated with [Claude Code](https://claude.com/claude-code)