### PR TITLE
The Animus Ferric Book (mdBook)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,6 @@ e2e_log_*.txt
 # start. The default now points at the shared suite store; override here only if
 # yours lives elsewhere.
 docker/.env
+
+# mdBook build output (source is docs/ + book.toml)
+/book

--- a/README.md
+++ b/README.md
@@ -18,7 +18,10 @@ Rust is not an implementation detail: the visible, demonstrable chain of ownersh
 
 ## Documentation
 
-Full docs live in **[`docs/`](docs/README.md)**:
+Full docs live in **[`docs/`](docs/README.md)**. They are also assembled into a
+book (via [mdBook](https://rust-lang.github.io/mdBook/), like *The Rust Book*) —
+run `mdbook serve --open` from the repo root, or read the same pages on GitHub
+below. The book's reading order is defined in [`docs/SUMMARY.md`](docs/SUMMARY.md).
 
 - **[Getting Started](docs/getting-started.md)** — install, prerequisites, and the external steps (engine install, `ferric server`) before your first run. Includes a no-model `--mock` quickstart.
 - **[Demo Guide](docs/demo-guide.md)** — a copy-paste walkthrough of every feature, each marked *offline* or *needs a model*.

--- a/book.toml
+++ b/book.toml
@@ -1,0 +1,21 @@
+# The Animus Ferric Book (mdBook).
+#
+# The book source IS the existing `docs/` folder — no files were moved. `docs/`
+# stays browsable on GitHub as-is; `docs/SUMMARY.md` sequences the same files
+# into a book. Build with `mdbook build` (output in `book/`, gitignored) or live-
+# preview with `mdbook serve --open`.
+[book]
+title = "The Animus Ferric Book"
+description = "Animus Ferric: a local-first agentic coding harness for small models — install, commands, configuration, running models, and the research/delegation subsystems."
+authors = ["crussella0129"]
+src = "docs"
+language = "en"
+
+[build]
+build-dir = "book"
+
+[output.html]
+default-theme = "rust"
+preferred-dark-theme = "ayu"
+git-repository-url = "https://github.com/crussella0129/Animus_Ferric"
+edit-url-template = "https://github.com/crussella0129/Animus_Ferric/edit/dev/{path}"

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -1,0 +1,47 @@
+# Summary
+
+[Why Animus?](introduction.md)
+
+# Getting Started
+
+- [Installation & First Run](getting-started.md)
+
+# Basic Features
+
+- [Your First Query](basics-query.md)
+- [Chatting, and `/do`](basics-chat.md)
+- [Loading a Skill](basics-skills.md)
+
+# Advanced Features
+
+- [Tool Rings & Capability Tiers](advanced-tool-rings.md)
+- [Benchmarking Your Model](testbench.md)
+- [Multimodal Input](multimodal.md)
+- [Ornstein — Quarantined Research](ornstein.md)
+- [ICM — Agent Delegation](icm.md)
+- [MCP & Animus Dark Matter](advanced-mcp.md)
+- [Agentic Cron](cron.md)
+
+# Advanced Ferric Server Configuration
+
+- [The Inference Server](server-configuration.md)
+  - [Installing llama.cpp](llama-cpp.md)
+
+# Animus Swarming with K8s
+
+- [Container Topology & Roadmap](swarming-k8s.md)
+
+# Animus By Example
+
+- [Worked Examples](by-example.md)
+
+# Reference
+
+- [Command Reference](commands.md)
+- [Configuration Reference](configuration.md)
+- [Environment Variables](environment.md)
+- [Credits & Citations](credits.md)
+
+# Appendix
+
+- [The Animus Project](appendix.md)

--- a/docs/advanced-mcp.md
+++ b/docs/advanced-mcp.md
@@ -1,0 +1,71 @@
+# MCP & Animus Dark Matter
+
+Animus speaks the [Model Context Protocol](https://modelcontextprotocol.io) two
+ways: it can *be* an MCP server (so an IDE or another agent can call a whole
+Ferric run as one tool), and it consumes an MCP-shaped knowledge seam that the
+sibling **Animus Dark Matter** project is being built to fill.
+
+## `ferric mcp` — Ferric as one MCP tool
+
+```sh
+ferric mcp [OPTIONS]
+```
+
+This starts an MCP-stdio server that exposes **exactly one** tool: `ferric_query`,
+taking `{prompt, files?}`. It never exposes Ferric's individual builtins, and
+never exposes workspace/backend/model as per-call parameters. Those are
+**launch-time-fixed** CLI flags held for the server's lifetime.
+
+That restriction is the whole point. Because the wire protocol has no field for
+the workspace or the model, an MCP client **cannot** redirect the run to another
+directory or swap the model — the containment guarantee is *structural*, not a
+policy check that could be forgotten. Every `tools/call` runs the same constrained
+agent loop `ferric query` drives, inheriting the guard, the tool rings, the
+loop-hardening guards, and per-call tracing.
+
+### Wiring it into a client
+
+Point any MCP-stdio client (an IDE, another agent, Claude Code, Cursor) at the
+command. A typical client config entry looks like:
+
+```json
+{
+  "mcpServers": {
+    "ferric": {
+      "command": "ferric",
+      "args": ["mcp", "--workspace", "/path/to/project", "--model", "your-model"]
+    }
+  }
+}
+```
+
+The client then sees a single `ferric_query` tool; calling it runs a full,
+contained Ferric agent turn against the fixed workspace and model.
+
+## Animus Dark Matter — the knowledge seam
+
+**Animus Dark Matter** ("Local Intelligence Multiplier") is a separate Animus
+Project repository (see [The Animus Project](appendix.md)). Its role is to be a
+knowledge layer the harness can query for *just* the context a task needs, rather
+than folding whole reference vaults into a prompt.
+
+The seam already exists on the Ferric side, in the [ICM](icm.md) delegation
+system. `ferric icm run --fetch-references` composes a stage with its own
+`references/` **withheld** and hands the model a `fetch_reference` tool to pull
+only the chunk(s) it queries. Measured on a 133 KB reference vault, this shrank a
+stage's prompt from 136,162 to 3,355 characters — **97.5% smaller** — with no loss
+of the references the stage actually used.
+
+> **Current state vs. intent.** `ferric mcp` and `fetch_reference` are built and
+> tested today. The in-tree `fetch_reference` backend (recursive read + heading
+> chunk + keyword score) is a deliberately simple stand-in that honors the *same
+> contract* a future **Animus Dark Matter MCP knowledge server** will implement.
+> Swapping the stand-in for the real Dark Matter server — a networked knowledge
+> service behind that contract — is stated intent, tracked in the Dark Matter
+> repo, not shipped here.
+
+## Related
+
+- [ICM — Agent Delegation](icm.md) — where `fetch_reference` lives.
+- [Ornstein — Quarantined Research](ornstein.md) — the *untrusted* retrieval
+  path, distinct from Dark Matter's trusted knowledge layer.

--- a/docs/advanced-tool-rings.md
+++ b/docs/advanced-tool-rings.md
@@ -1,0 +1,87 @@
+# Tool Rings & Capability Tiers
+
+The tool ring model is the most load-bearing idea in Animus after harness-owned
+decoding itself. It is how a small model is given *exactly* the tool vocabulary it
+can drive reliably — no more — and how that vocabulary widens only as the model
+earns it.
+
+## The problem it solves
+
+Give a model a tool it cannot reliably call and you do not get a slightly worse
+agent; you get a stuck one — it reaches for the tool, malforms the call, and
+burns turns. The fix is not "more prompting." It is to **not offer** tools the
+model has not proven it can use. The offered tools *are* the constrained grammar,
+so restricting them is restricting what the model can even emit.
+
+## The rings
+
+Tools are organized into concentric rings that widen as reliability is proven:
+
+- **Ring 0 — the navigate/mutate core** (always on): `read_file`, `list_dir`,
+  `write_file`, `make_dir`, `edit_file` (surgical first-occurrence replace — small
+  models do targeted edits far more reliably than full rewrites), and
+  `delete_path` (guarded, `recursive`-gated). This is the smallest, surest grammar
+  — every model gets it.
+- **Ring 1 — "find & organize"**: `search_files` (grep-style content search →
+  `relpath:lineno:line`), `find_files` (by name), `move_path`, `copy_file`.
+- **Ring 2 — "plan & apply structured changes"**: `multi_edit` (an ordered,
+  *atomic* batch of edits to one file), `apply_patch` (a context-located unified
+  diff — its context disambiguates *which* occurrence to edit), and, at the top,
+  `shell_exec`.
+
+Outer rings assume the model can already drive the inner ones; the loop **trims
+from the outer ring first**, so the core is never dropped.
+
+## Tiers
+
+A model runs at a **tier** — `Nano`, `Small`, `Medium`, `Large`, `Xl`, `Ultra` —
+which sets the ceiling on how wide the rings go, plus the turn and tool-call
+budgets. Tier is derived, in order of authority:
+
+1. an explicit `--tier` (operator override, recorded as such);
+2. a persisted `measured_level` from benchmarking (the *earned* tier);
+3. otherwise a prior from the parameter count (`--params-b`).
+
+The key finding behind all of this: **single-tool-call reliability is not agentic
+capability.** A 1B model can fire a correct single call at 100% and still be unable
+to complete a multi-turn task. Tiers are set by measured multi-turn completion, not
+by size or by single-shot fire rate.
+
+## Earning a wider grammar
+
+You do not have to trust the defaults. Prove a model and let it promote itself:
+
+```sh
+# Measure single-tool fire rate ring-by-ring and report the highest ring it
+# reliably drives (the recommended --max-ring):
+ferric bench ltd --model <name> --protocol grammar --calibrate-rings --profile-dir benchmarks
+
+# Measure multi-turn task completion across the L0–L6 ladder -> measured_level:
+ferric bench full --model <name> --protocol grammar --results-dir benchmarks
+```
+
+These write `benchmarks/model_profiles.json`. A later `ferric query --profile-dir
+benchmarks` **reads that profile back** and auto-runs the model at its earned tier
+(`measured_level`) and calibrated ring — no manual flag. See
+[Benchmarking Your Model](testbench.md) for the full workflow.
+
+## Controlling rings directly
+
+```sh
+ferric query "…" --max-ring 0   # pin any model to the Ring-0 core, whatever its size
+```
+
+`--max-ring` is **restrict-only**: it can narrow the grammar below the tier
+ceiling, but it cannot widen a model past what it has earned. To widen, you
+benchmark. This asymmetry is deliberate — capability is demonstrated, never
+asserted.
+
+## Guards that bound the waste
+
+Because a model *can* be handed a ceiling it cannot fully use, a family of
+loop-hardening guards bounds the cost of a model that gets stuck: the **repetition
+guard** (identical calls), the **no-progress guard** (same tool name, different
+args, no progress), and the **repeated-failure guard** (consecutive all-errored
+turns). They compose by threshold and stop a stuck run early with a precise reason
+(`no_progress`, `repeated_failure`) instead of grinding to `max_turns`. They bound
+wasted compute and sharpen diagnostics — they do not lift a capability ceiling.

--- a/docs/appendix.md
+++ b/docs/appendix.md
@@ -1,0 +1,65 @@
+# The Animus Project
+
+Animus Ferric is one component of a larger whole. **[The Animus
+Project](https://github.com/crussella0129/The_Animus_Project)** describes itself
+as *"an open-source ecosystem of accessible and highly performant local AI
+applications"* — model harnesses provide the AI infrastructure, while a set of
+tools and agent skills deliver specialized functionality on top.
+
+This appendix summarizes the sibling components and how Ferric relates to each.
+Status labels (*Current* / *Under Development* / *Deprecated*) are as listed on
+the project's own overview; follow the project link above for the authoritative,
+up-to-date roster.
+
+## Model harnesses
+
+The harness runs a local model. Ferric is the current one; the others are its
+lineage.
+
+- **Animus Ferric** *(Current)* — this project. The active harness: harness-owned
+  decoding for small local models.
+- **Animus Fev** *(Deprecated)* — a previous harness iteration.
+- **Animus Prion** *(Deprecated)* — an earlier harness version, no longer
+  maintained.
+- **Animus 1.0** *(Deprecated)* — the original harness foundation.
+
+## Tools & agent skills
+
+These sit alongside the harness. Several connect to Ferric directly:
+
+- **Animus Sprint-Loops** *(Current)* — the workflow-management and agent-
+  coordination system. The five-phase sprint loop (Research → Plan → Build → Test
+  → Loop) this project is developed under.
+- **Animus Dark Matter — Local Intelligence Multiplier** *(Under Development)* —
+  a knowledge layer that serves a task *just* the context it needs. Ferric already
+  implements its side of the seam: the [`fetch_reference`](advanced-mcp.md) tool in
+  [ICM](icm.md), whose in-tree backend is a stand-in for Dark Matter's future MCP
+  knowledge server.
+- **Animus AutoResearch** *(Current)* — automated research capabilities;
+  conceptually adjacent to Ferric's own [Ornstein](ornstein.md) quarantined-
+  research subsystem.
+- **Animus GECK** *(Current)* — a toolset component. Ferric's `ferric launch`
+  bootstrapper is the in-harness descendant of this scaffolding lineage.
+- **Animus IDE** *(Under Development)* — an integrated development environment; the
+  intended graphical organ that would drive Ferric's `chat` and `mcp` surfaces.
+- **Animus Model Lab** *(Under Development)* — a testing environment for model
+  experimentation (fine-tunes, conversions, evaluation).
+- **Animus Neutronium** *(Current)* — an active operational component (front-end /
+  UI-layer engineering).
+- **Animus Puccinia** *(Under Development)* — an emerging system module.
+
+## How Ferric fits
+
+Ferric is the **spine** ([Why Animus?](introduction.md)) — the harness that turns a
+small model's intent into reliable, contained action. The other components extend
+it outward: Dark Matter feeds it sharper knowledge, AutoResearch and Ornstein feed
+it the outside world under quarantine, Sprint-Loops governs how it is built, GECK
+and Launch bootstrap new work, and the IDE will eventually give it a face. Animus
+Ophanim (see [The Inference Server](server-configuration.md)) is the intended
+native engine that will one day replace the external llama.cpp backend Ferric
+drives today.
+
+> Component names, status, and scope evolve. Treat
+> [The Animus Project overview](https://github.com/crussella0129/The_Animus_Project)
+> as the source of truth; this appendix is a snapshot with Ferric's perspective
+> added.

--- a/docs/basics-chat.md
+++ b/docs/basics-chat.md
@@ -1,0 +1,73 @@
+# Chatting, and `/do`
+
+`ferric query` is one-shot. `ferric chat` is the interactive counterpart: a REPL
+where you can talk with the model freely and, when you actually want it to *act*,
+escalate a single turn into the constrained agentic loop with `/do`.
+
+```sh
+ferric chat
+```
+
+## Two kinds of turn, one conversation
+
+Chat deliberately separates **talking** from **doing**, and the separation is
+structural, not a matter of prompting:
+
+- **Talk (the default).** Anything you type is a plain, unconstrained completion:
+  the model replies as text. This path has **no tools and no constraint** — its
+  output is printed and added to the conversation history, and that is all. It is
+  never parsed for a tool call and never dispatched. The model literally cannot
+  act from a talk turn, because a talk turn does not go through the dispatching
+  loop.
+
+- **Do (`/do <request>`).** Prefixing a message with `/do` promotes *that one
+  turn* into the same constrained agentic loop `ferric query` runs — tools, the
+  guard, the loop-hardening guards, and a fresh trace file — seeded with the
+  conversation so far as context. When it finishes, you are back in talk mode.
+
+This is why chat is safe by default: **only you** can escalate into acting. The
+model can suggest, explain, and plan in talk mode, but it can never promote itself
+into doing something. That boundary is a deliberate security property (a model
+that could self-escalate into tool use would be a model that could act on
+injected instructions).
+
+## A session, end to end
+
+```
+you> what does the loop guard family protect against?
+model> (a plain explanation — no tools ran)
+
+you> /do add a doc-comment to ProgressGuard summarizing that
+▸ calling read_file...
+✓ read_file: crates/ferric-loop/src/progress.rs
+▸ calling edit_file...
+✓ edit_file: added the doc comment
+[task_complete after 2 turn(s); trace: .ferric/trace/q-...jsonl]
+
+you> thanks
+model> (talk again)
+```
+
+Each `/do` writes its **own** agentic trace file, exactly as a standalone
+`ferric query` would; the talk turns are logged separately as a chat-session log.
+
+## REPL commands
+
+| Command | Effect |
+|---|---|
+| `/do <request>` | escalate this turn into the constrained agentic loop |
+| `/help` | list the available commands |
+| `/exit` or `/quit` | leave the REPL |
+
+## Launch-time-fixed settings
+
+Like `ferric mcp`, chat fixes its workspace, model, and protocol **once** at
+launch — they are ordinary CLI flags held for the whole session, not something a
+turn can change mid-conversation. That, again, is containment by construction: no
+turn can redirect the workspace or swap the model, because there is no channel for
+it to do so.
+
+---
+
+Next: [Loading a Skill](basics-skills.md) — giving the model a reusable
+instruction set for a run.

--- a/docs/basics-query.md
+++ b/docs/basics-query.md
@@ -1,0 +1,88 @@
+# Your First Query
+
+`ferric query` is the core of Animus: one workspace-scoped, fully-traced agent
+run against a local model. Everything else — chat, MCP, benchmarking, the API —
+is built on top of the same loop this command drives.
+
+## The shape of a query
+
+```sh
+ferric query "<prompt>" [OPTIONS]
+```
+
+A query runs the model in a **constrained agentic loop**: the model proposes a
+tool call, the harness validates and executes it inside the workspace, feeds the
+result back, and repeats until the model calls `task_complete` or a budget/guard
+stops it. Every step is written to a JSONL trace under `.ferric/trace/`.
+
+## No model needed: `--mock`
+
+You do not need a running model to see the loop work. The built-in mock runs a
+scripted turn — a file write, then a structured completion — exercising the full
+loop, guard, and trace path:
+
+```sh
+ferric query "do a mock task" --mock
+```
+
+This is the fastest way to confirm your build works and to see the trace format.
+
+## A real run
+
+For a real model, first stand up an inference server (covered in
+[Installation & First Run](getting-started.md) and, in depth, in
+[The Inference Server](server-configuration.md)):
+
+```sh
+ferric server up --engine llama-server --model /path/to/model.gguf
+ferric query "list the Rust files and summarize lib.rs"
+ferric server down
+```
+
+`query` **auto-discovers** the running server from `.ferric/server.json` — you do
+not pass `--api-base` unless you are targeting a server you did not launch (for
+example an already-running Ollama at `http://localhost:11434/v1`).
+
+> Real-model queries require a binary built with `--features backend-openai`. A
+> feature-less build still runs `--mock` and the offline tooling, and will tell
+> you to rebuild if you ask it for a real run.
+
+## The workspace is the boundary
+
+A query operates on a **workspace** — by default the current directory, or an
+explicit `--workspace <DIR>`. This is a hard containment boundary: the built-in
+tools (`read_file`, `write_file`, `edit_file`, …) are checked against it through
+`ferric-guard`, and a `.ferricignore` file can put further paths off-limits. The
+model cannot read or write outside the workspace, and cannot read sensitive files
+(`.env`, SSH keys, cloud credentials) even inside it.
+
+## A few flags you will reach for early
+
+| Flag | What it does |
+|---|---|
+| `--mock` | run the scripted mock; no model needed |
+| `--workspace <DIR>` | set the containment boundary (default: current dir) |
+| `--file <PATH>` | attach a file (repeatable); text folds into the prompt, media attaches when `--modality` allows |
+| `--stream` is on by default | text and tool activity print live; `--no-stream` to suppress |
+| `--model <NAME>` | the model id your server expects |
+| `--max-ring <N>` | cap the active [tool ring](advanced-tool-rings.md) (restrict-only) |
+
+The full flag list is in the [Command Reference](commands.md); persistent
+defaults (so you stop repeating flags) live in
+[Configuration](configuration.md).
+
+## Reading the result
+
+When the run ends, Ferric prints the final answer and a one-line summary:
+
+```
+[task_complete after 3 turn(s); trace: .ferric/trace/q-1785504463287.jsonl]
+```
+
+That trace file is the source of truth for what happened — render it any time
+with `ferric trace cat <file>`.
+
+---
+
+Next: [Chatting, and `/do`](basics-chat.md) — the interactive counterpart to the
+one-shot query.

--- a/docs/basics-skills.md
+++ b/docs/basics-skills.md
@@ -1,0 +1,66 @@
+# Loading a Skill
+
+A **skill** is a reusable instruction set — a named block of guidance you can pull
+into a run's system prompt on demand, instead of retyping it or baking it into
+every prompt. Skills live per-workspace under `.ferric/skills/`.
+
+## Seeing what's installed
+
+```sh
+ferric skills list
+```
+
+This lists every skill in `.ferric/skills/` and shows how each one would be
+authorized — whether it is standing-authorized for the workspace, or must be named
+explicitly per run.
+
+## Using a skill for a run
+
+Name the skill on the invocation with `--skill` (repeatable):
+
+```sh
+ferric query "refactor the parser" --skill rust-review --skill terse-commits
+```
+
+**Naming the skill *is* the authorization.** It is you, on this invocation, asking
+for that guidance to be in scope. This matters: a skill sitting in
+`.ferric/skills/` is visible to `ferric skills list` but contributes *nothing* to
+a prompt until you say so. There is no channel through which the model can enable
+a skill for itself — the authorization only ever comes from your flags or your
+config, never from anything the model emits.
+
+If you name a skill that isn't installed, Ferric tells you rather than silently
+running without it:
+
+```
+skill: no skill named `rust-reviw` is installed in .ferric/skills/
+```
+
+(A typo that quietly runs nothing is exactly the failure this guard prevents.)
+
+## Standing authorization
+
+If you always want certain skills available without naming them every time, list
+them in `allowed_skills` in `.ferric/config.toml`:
+
+```toml
+allowed_skills = ["rust-review", "terse-commits"]
+```
+
+A project allowlist **replaces** the user's rather than extending it, so a repo
+cannot silently inherit skills you enabled globally. And because config lives
+under `.ferric/` — which the guard write-denies to the model — the allowlist is
+something only *you* can edit. An allowlist the agent could rewrite would authorize
+nothing.
+
+## Why skills are a security surface, not just a convenience
+
+Everything above is the same principle in a different place: authorization flows
+in one direction, from you to the run, and never back from the model. A skill is
+just trusted instructions you chose to add — like the project's `Animus.md` file,
+and unlike anything Ornstein retrieves, which is quarantined as untrusted data.
+
+---
+
+That's the basics. From here, the [Advanced Features](advanced-tool-rings.md)
+part covers tool rings, research, delegation, MCP, and more.

--- a/docs/by-example.md
+++ b/docs/by-example.md
@@ -1,0 +1,181 @@
+# Worked Examples
+
+This is the gauntlet: complete, copy-pasteable runs that exercise every feature
+covered earlier, from a first mock run to a full research-and-act loop. It is
+meant to grow into the longest part of the book — a worked implementation for each
+capability, basic and advanced, plus purpose-built server setups.
+
+> **This chapter grows.** The examples below are real and runnable today. More
+> will be added as features land and as specialized recipes are worked out; that
+> expansion is stated intent, tracked here so it is not forgotten. Examples that
+> depend on an unbuilt feature are marked.
+
+Each example lists what it needs, the commands, and what you should see.
+
+---
+
+## 1. Zero to first run — no model
+
+*Needs: a built `ferric` (any features).*
+
+```sh
+ferric query "do a mock task" --mock
+```
+
+Expected: a scripted file write, then a `task_complete`, ending with
+`[task_complete after 2 turn(s); trace: .ferric/trace/q-….jsonl]`. Render the
+trace:
+
+```sh
+ferric trace cat .ferric/trace/q-*.jsonl
+```
+
+---
+
+## 2. A real query against a served model
+
+*Needs: `--features backend-openai`, `llama-server`, a GGUF.*
+
+```sh
+ferric server up --engine llama-server --model ./model.gguf
+ferric server status
+ferric query "list the Rust files and summarize the largest one"
+ferric server down
+```
+
+Expected: `query` auto-discovers the server from `.ferric/server.json`, runs a
+constrained multi-turn loop, and prints a summary. No `--api-base` needed.
+
+---
+
+## 3. Talk, then act, in one session
+
+*Needs: a served model.*
+
+```sh
+ferric chat
+```
+
+```
+you> what would it take to add a --version flag here?
+model> (a plain explanation — no tools ran)
+you> /do add it
+▸ calling edit_file...
+✓ edit_file: added the flag
+[task_complete after 2 turn(s); trace: …]
+you> /exit
+```
+
+Expected: talk turns never touch the filesystem; only the `/do` turn runs the
+agentic loop and writes a trace. See [Chatting, and `/do`](basics-chat.md).
+
+---
+
+## 4. Measure a model, then let it promote itself
+
+*Needs: a served model.*
+
+```sh
+# Single-tool fire rate, ring by ring:
+ferric bench ltd --model your-model --protocol grammar --calibrate-rings --profile-dir benchmarks
+# Multi-turn task completion across L0–L6:
+ferric bench full --model your-model --protocol grammar --results-dir benchmarks
+# Now a normal query auto-runs at the earned tier + ring:
+ferric query "refactor the config loader" --profile-dir benchmarks
+```
+
+Expected: `benchmarks/model_profiles.json` records `measured_level` and
+`calibrated_ring`; the final query reads them back and runs at the *earned* tier
+with no manual `--tier`/`--max-ring`. See [Tool Rings & Capability
+Tiers](advanced-tool-rings.md) and [Benchmarking Your Model](testbench.md).
+
+---
+
+## 5. An edge-tuned server
+
+*Needs: `llama-server`, a GGUF, a constrained machine (or just to try the flags).*
+
+```sh
+ferric server up --engine llama-server --model ./model.gguf \
+  --ctx 8192 --threads 4 --gpu-layers 20 --batch-size 256
+ferric server doctor --engine llama-server --model ./model.gguf
+```
+
+Expected: the launcher maps these to `-c/-t/-ngl/-b` on `llama-server`, bound to
+`127.0.0.1`. `doctor` confirms the binary and model are present. See [The
+Inference Server](server-configuration.md).
+
+---
+
+## 6. Reading an image
+
+*Needs: a served model with a projector (`--mmproj`).*
+
+```sh
+ferric server up --engine llama-server --model ./vlm.gguf --mmproj ./mmproj.gguf
+ferric query --file diagram.png --modality image "describe the diagram"
+```
+
+Expected: the image attaches as a content part (because `--modality image` is
+declared and the backend carries media) and the model answers. See [Multimodal
+Input](multimodal.md).
+
+---
+
+## 7. Research a workspace, quarantined
+
+*Needs: a served model.*
+
+```sh
+ferric query "summarize how errors are handled here" --research "error handling"
+```
+
+Expected: Ferric searches the workspace, routes matches through the Ornstein
+quarantine (a tools-free, memory-free, data-only summarizer), and folds the
+provenance-tagged digest into the prompt. Because untrusted content entered the
+run, later mutations are gated by the `--sink-action` policy. See
+[Ornstein — Quarantined Research](ornstein.md).
+
+---
+
+## 8. Delegate across stages with ICM
+
+*Needs: nothing for `init`/`plan`; a served model for `run`.*
+
+```sh
+ferric icm init ./pipeline          # scaffold a 3-stage workspace (offline)
+ferric icm plan ./pipeline          # print the orchestration plan (offline)
+ferric icm run ./pipeline           # execute the pipeline
+```
+
+Expected: `init` and `plan` are fully offline; `run` drives each stage as a
+contained agent turn, the folder structure *being* the orchestration. See [ICM —
+Agent Delegation](icm.md).
+
+---
+
+## 9. Expose Ferric to an IDE over MCP
+
+*Needs: a served model, an MCP client.*
+
+```sh
+ferric mcp --workspace ./project --model your-model
+```
+
+Point an MCP-stdio client at that command; it sees one tool, `ferric_query`, that
+runs a full contained Ferric turn. See [MCP & Animus Dark Matter](advanced-mcp.md).
+
+---
+
+## 10. Purpose-built recipes *(intent — growing)*
+
+Planned additions to this gauntlet, recorded so they are not lost:
+
+- A CPU-only Raspberry Pi setup end-to-end, with the tier the hardware actually
+  earns.
+- A fleet leaderboard sweep choosing the smallest "solid" model for a task.
+- A scheduled agent via [`ferric cron`](cron.md).
+- A resumable long run (`--resume`) after an interruption.
+- Server recipes tuned per model class (small chat model vs. code model vs. VLM).
+
+These are intended examples, not yet written.

--- a/docs/credits.md
+++ b/docs/credits.md
@@ -1,0 +1,68 @@
+# Credits & Citations
+
+Animus Ferric stands on a great deal of open-source work and a handful of
+published ideas. This page records both. License terms belong to each project;
+follow the links for the authoritative text.
+
+## Inference engines & infrastructure
+
+| Project | Role in Animus | License |
+|---|---|---|
+| [llama.cpp](https://github.com/ggml-org/llama.cpp) (`llama-server`) | the default inference backend behind the HTTP valve | [MIT](https://github.com/ggml-org/llama.cpp/blob/master/LICENSE) |
+| [llguidance](https://github.com/guidance-ai/llguidance) | grammar-constrained decoding inside the server (the mechanism behind harness-owned decoding) | [MIT / Apache-2.0](https://github.com/guidance-ai/llguidance) |
+| [Ollama](https://github.com/ollama/ollama) | pluggable alternative engine (`--engine ollama`) | [MIT](https://github.com/ollama/ollama/blob/main/LICENSE) |
+| [gVisor](https://github.com/google/gvisor) (`runsc`) | microVM-class sandbox runtime for Ornstein's airlock | [Apache-2.0](https://github.com/google/gvisor/blob/master/LICENSE) |
+| [Docker](https://www.docker.com/) | container topology for the platform (see [Swarming](swarming-k8s.md)) | [Apache-2.0 / proprietary components](https://www.docker.com/legal/) |
+| [Tailscale](https://tailscale.com/) | optional secure remote exposure (`--tailscale`) | [BSD-3-Clause (core)](https://github.com/tailscale/tailscale/blob/main/LICENSE) |
+| [mdBook](https://github.com/rust-lang/mdBook) | builds this book from `docs/` | [MPL-2.0](https://github.com/rust-lang/mdBook/blob/master/LICENSE) |
+
+## Rust dependencies
+
+The harness itself is Rust. Its direct external crates, each on
+[crates.io](https://crates.io) with its own license (the ecosystem norm is
+`MIT OR Apache-2.0`):
+
+- **CLI & runtime:** [`clap`](https://crates.io/crates/clap),
+  [`tokio`](https://crates.io/crates/tokio),
+  [`futures-executor`](https://crates.io/crates/futures-executor),
+  [`rustyline`](https://crates.io/crates/rustyline)
+- **Serialization & text:** [`serde`](https://crates.io/crates/serde),
+  [`serde_json`](https://crates.io/crates/serde_json),
+  [`toml`](https://crates.io/crates/toml),
+  [`regex`](https://crates.io/crates/regex),
+  [`chrono`](https://crates.io/crates/chrono)
+- **HTTP & server:** [`reqwest`](https://crates.io/crates/reqwest) (with
+  `rustls-tls`, no native OpenSSL), [`axum`](https://crates.io/crates/axum),
+  [`tokio-stream`](https://crates.io/crates/tokio-stream)
+- **Errors, async, temp, observability:**
+  [`thiserror`](https://crates.io/crates/thiserror),
+  [`async-trait`](https://crates.io/crates/async-trait),
+  [`tempfile`](https://crates.io/crates/tempfile),
+  [`tracing`](https://crates.io/crates/tracing) +
+  [`tracing-subscriber`](https://crates.io/crates/tracing-subscriber)
+- **Prompt composition:** [`oovra`](https://github.com/crussella0129/oovra) — a
+  sibling Animus Project library, rev-pinned.
+
+## Papers & ideas
+
+The design draws directly on published work:
+
+- **ReAct** — Yao et al., *ReAct: Synergizing Reasoning and Acting in Language
+  Models*, 2022 ([arXiv:2210.03629](https://arxiv.org/abs/2210.03629)). The
+  reason-then-act loop that agentic harnesses, Animus included, are built around.
+- **CaMeL** — Debenedetti et al. (Google DeepMind), *Defeating Prompt Injections
+  by Design*, 2025 ([arXiv:2503.18813](https://arxiv.org/abs/2503.18813)). The
+  capabilities/taint model behind Ferric's "CaMeL-lite" sink policy
+  (`--sink-action`).
+- **ICM** — Van Clief & McDermott, *Interpretable Context Methodology: Folder
+  Structure as Agent Architecture*, 2026. The delegation model where the
+  filesystem *is* the orchestration layer; adapted in [ICM — Agent
+  Delegation](icm.md).
+- **The lethal trifecta** — Simon Willison,
+  [*The lethal trifecta for AI agents*](https://simonwillison.net/2025/Jun/16/the-lethal-trifecta/),
+  2025. The private-data + untrusted-content + exfiltration framing that
+  [Ornstein](ornstein.md)'s structural quarantine is designed against.
+
+> If you believe an attribution here is incorrect or incomplete — a wrong
+> license, a missing project, a citation that should point elsewhere — that is a
+> bug in this page; please open an issue.

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -1,0 +1,115 @@
+# Why Animus?
+
+**Animus Ferric** is a local-first, agentic coding harness built for *small*
+models — the kind that run on a laptop, a Jetson, or a Raspberry Pi, with no API
+key and no data leaving the machine. This book is its manual, and also, by
+design, a record of where it is going (see [How this book works](#how-this-book-works)
+below).
+
+Before you invest in it, the honest question is: **why this, and not something
+bigger?**
+
+## When Animus is the right tool — and when it isn't
+
+There is a class of coding agents you already know: large, cloud-hosted harnesses
+driving frontier models through an API. They are excellent. For what they solve,
+they are genuinely more sophisticated than Animus, and this book will not pretend
+otherwise. If you have a capable model and the budget to call it, reach for one
+of those.
+
+Animus is built for the *other* situation — and the two do not substitute for
+each other in either direction:
+
+- **A big harness would crush a small model.** The large agents assume a model
+  that can hold a sprawling context, recover from its own malformed output, and
+  reason across many loosely-specified tool calls. Hand that machinery a 1B model
+  and it flails. Animus assumes the opposite: the model is small and will not
+  reliably emit a correct tool call on its own — so the *harness* guarantees
+  correctness instead (see [harness-owned decoding](#the-thesis-the-harness-owns-decoding)).
+
+- **Animus is not the token-efficient choice for a big model.** The same
+  guardrails that make a 1B model usable — constrained grammars, tight tool
+  rings, structural containment — are overhead a frontier model does not need and
+  would arguably be *slower* and more token-hungry running under them than under a
+  harness designed around its strengths. The larger agents appear to run as
+  ReAct-style loops operating at the level of the operating system itself; that is
+  a fundamentally different design, and (we should be candid) one Animus has not
+  benchmarked head-to-head. Different tools, different problems.
+
+So: choose Animus when the model is small, the machine is yours, the data must
+stay local, or the target is the edge. Choose a bigger agent when you have a
+capable model, an API budget, and a task that rewards raw model sophistication.
+Neither choice is a compromise; they are answers to different questions.
+
+## The philosophy
+
+The Animus Project operates on a single principle:
+
+> **The simplest, most efficient design *is* the most sophisticated one.**
+
+This is not a concession — "small, therefore humble." It is the claim itself.
+Sophistication is not measured in parameters or in the sprawl of the machinery
+around a model. It is measured in how much reliable capability you extract per
+unit of complexity. A harness that makes a 1B model complete real multi-turn
+tasks — by *removing* the ways it can fail rather than by piling on more
+inference — is doing the more sophisticated thing, not the lesser one.
+
+### Spine thinkers
+
+A useful picture. Dinosaurs had famously tiny brains, yet they operated enormous,
+capable bodies with precision. The work was not all done in the head: their
+massive, elaborate spinal architecture carried an enormous share of the
+coordination. They were, in a sense, *spine thinkers*.
+
+Animus is built on the same division of labor. **The model is the brain; the
+harness is the spine.** The brain supplies intent — what to do next. The spine
+supplies structure, reflex, and safety — it constrains what a malformed impulse
+can become, it holds the body's boundaries, it turns a small signal into a
+reliable action. Give a modest brain a sophisticated enough spine and it drives a
+body far larger than its size would suggest.
+
+Everything in this book is, ultimately, spine.
+
+## The thesis: the harness owns decoding
+
+Concretely, the spine's central mechanism is **harness-owned decoding**. Rather
+than trusting the model to emit a well-formed tool call and hoping for the best,
+Animus constrains generation to a JSON grammar it controls, enforced server-side.
+The model cannot emit an invalid action because the invalid tokens are never
+offered to it. This is what extends the usable floor down to a 1B model, where an
+unconstrained model's own tool-calling collapses.
+
+From that one idea the rest follows: [tool rings](advanced-tool-rings.md) that
+widen only as a model *proves* it can drive them; a [structural
+quarantine](ornstein.md) that lets untrusted research reach the model as data but
+never as an action; [containment](icm.md) that lives in the filesystem rather than
+a coordination framework. Small pieces, each doing one thing, each removing a way
+to fail.
+
+## How this book works
+
+This book is built with [mdBook](https://rust-lang.github.io/mdBook/), the same
+tool behind *The Rust Programming Language*. Its source is this repository's
+`docs/` folder, so every page is also browsable directly on GitHub.
+
+It serves two purposes at once, and it tells you which is which:
+
+- **Documentation of what exists.** Most chapters describe shipped, tested
+  behavior. Commands shown here work today.
+- **A record of stated intent.** Some sections — most explicitly [Animus Swarming
+  with K8s](swarming-k8s.md), and parts of [Animus By Example](by-example.md) —
+  describe where the project is *going*. These are marked clearly as intent, not
+  as current fact. The book is meant to be the project's durable statement of
+  direction, the place a future sprint reads to know what it was asked to build.
+
+Where a chapter mixes the two, it says so inline.
+
+## Where to go next
+
+- New here? [Installation & First Run](getting-started.md) gets you from `git
+  clone` to a first query.
+- Want the basics? [Your First Query](basics-query.md), [Chatting and
+  `/do`](basics-chat.md), and [Loading a Skill](basics-skills.md).
+- Ready to go deep? The [Advanced Features](advanced-tool-rings.md) part is the
+  long one.
+- Just need a flag? The [Command Reference](commands.md).

--- a/docs/server-configuration.md
+++ b/docs/server-configuration.md
@@ -1,0 +1,129 @@
+# The Inference Server
+
+Animus does not contain a model runner. It drives an **OpenAI-compatible HTTP
+server** — the "valve" — and `ferric server` is the lifecycle manager for it.
+This chapter goes beyond "launch it with a model" and covers the full surface:
+the lifecycle, every launch flag, edge tuning, multimodal, and secure exposure.
+
+The default engine is llama.cpp's `llama-server`; Ollama is pluggable via
+`--engine ollama`. (Installing `llama-server` itself is covered in
+[Installing llama.cpp](llama-cpp.md).)
+
+## Lifecycle
+
+```sh
+ferric server up      # launch + register (writes .ferric/server.json)
+ferric server status  # health-check the registered server, print its base URL
+ferric server doctor  # check engine-binary + model presence (and reachability)
+ferric server down    # stop it and remove the runfile
+```
+
+`up` writes a **runfile** at `.ferric/server.json` recording the engine, PID,
+port, and base URL. This is what lets `ferric query` and `ferric bench`
+**auto-discover** the server — you launch once and everything else finds it, no
+`--api-base` needed.
+
+`doctor` is the pre-flight check; it validates presence *without* launching:
+
+```console
+$ ferric server doctor --engine llama-server --model ./model.gguf
+[ok] engine binary `llama-server`
+[MISSING] model `./model.gguf`
+[warn] registered server http://127.0.0.1:8080/v1 is not reachable
+```
+
+`status` reports the registered server and whether it is actually answering:
+
+```console
+$ ferric server status
+engine=LlamaServer pid=36792 base_url=http://127.0.0.1:8080/v1 (NOT reachable)
+```
+
+## Launch flags
+
+`ferric server up` accepts:
+
+| Flag | Default | Purpose |
+|---|---|---|
+| `--engine <llama-server\|ollama>` | `llama-server` | which engine to launch |
+| `--model <PATH\|NAME>` | — | GGUF path (llama-server) or model name (Ollama) |
+| `--mmproj <PATH>` | — | multimodal projector GGUF (image/audio/video) |
+| `--ctx <N>` | `4096` | context window in tokens |
+| `--port <N>` | `8080` | port to bind **on 127.0.0.1** |
+| `--threads <N>` | engine default | CPU threads (llama-server only) |
+| `--gpu-layers <N>` | engine default | layers to offload to GPU (llama-server only) |
+| `--batch-size <N>` | engine default | batch size (llama-server only) |
+| `--tailscale` | off | expose the port over Tailscale Serve |
+
+### How the flags map to `llama-server`
+
+Ferric builds a closed, audited command line — it never execs an arbitrary
+binary (the engine is a fixed enum). The mapping is:
+
+| Ferric flag | `llama-server` argument |
+|---|---|
+| `--model` | `-m <path>` |
+| `--mmproj` | `--mmproj <path>` |
+| `--ctx` | `-c <n>` |
+| `--threads` | `-t <n>` |
+| `--gpu-layers` | `-ngl <n>` |
+| `--batch-size` | `-b <n>` |
+| `--port` | `--port <n>` |
+| (fixed) | `--host 127.0.0.1` |
+
+For Ollama, `--engine ollama` runs `ollama serve` with `OLLAMA_HOST` set to the
+chosen host:port; the llama-server-only tuning flags are ignored.
+
+## Loopback-only, by design
+
+The host is **pinned to `127.0.0.1`** and is not configurable. The launcher never
+binds a public interface. This is ADR-005: the harness and its backend talk only
+over loopback, so an inference server Ferric launched is never reachable from off
+the machine. This is also why, in the containerized topology, `ferric` and
+`llama-server` are co-located in one container rather than split across a network
+boundary (see [Container Topology & Roadmap](swarming-k8s.md)).
+
+If you genuinely need remote access, `--tailscale` exposes the port over your
+tailnet via Tailscale Serve (requires the `tailscale` CLI, and the first run on a
+machine prints an authorization link you must click). This is an explicit,
+authenticated opt-in — not a public bind.
+
+## Edge tuning
+
+`--threads`, `--gpu-layers`, and `--batch-size` exist for constrained targets —
+Jetson, Raspberry Pi, and similar. On a CPU-bound edge box, thread count is the
+primary latency lever; on a small GPU, `--gpu-layers` decides how much of the
+model is offloaded. A representative edge launch:
+
+```sh
+ferric server up --engine llama-server --model ./model.gguf \
+  --ctx 8192 --threads 4 --gpu-layers 20 --batch-size 256
+```
+
+Tune, then **measure** — the [testbench](testbench.md) tells you whether a given
+configuration still drives the tools reliably, which is the number that actually
+matters for an agent.
+
+## Multimodal
+
+Pass `--mmproj` alongside `--model` to load a vision/audio projector; the model
+can then read images and audio when the query declares `--modality`. See
+[Multimodal Input](multimodal.md) for the full pipeline.
+
+## Looking ahead: Animus Ophanim
+
+Today the engine is external — llama.cpp via the HTTP valve — and this chapter is
+about configuring *that*. The Animus Project's stated direction is a
+**native-Rust inference engine, Animus Ophanim**, that will eventually replace
+llama.cpp as the default backend and fold the runner into the harness's own
+process and language.
+
+> The name is deliberate. The *ophanim* are the wheels of the divine chariot —
+> "wheels within wheels," full of eyes, that carry the whole apparatus and move
+> wherever the spirit directs. An inference engine is exactly that: the wheels
+> that actually move the body, nested computation within computation, all
+> attention, going wherever the model's intent points. The spine drives; Ophanim
+> is what it drives *with*.
+
+Until Ophanim ships, everything in this chapter is how you get the most out of
+the llama.cpp valve. **(Animus Ophanim is stated intent — not yet built.)**

--- a/docs/swarming-k8s.md
+++ b/docs/swarming-k8s.md
@@ -1,0 +1,78 @@
+# Container Topology & Roadmap
+
+> **This chapter is mostly stated intent.** The single-node container topology
+> exists and is described first as current fact. Multi-node **swarming with
+> Kubernetes** is *not built yet* — it is recorded here as direction, so a future
+> sprint reads this page to know what it was asked to build. Where a line
+> describes something shipped, it says so.
+
+## Two problems, two tools
+
+Container work in Animus was shaped by one correction (ADR-051): "run it in
+containers" conflates two unrelated problems, and they need different tools.
+
+1. **Deployment flexibility** — running the platform anywhere from one laptop to a
+   datacenter. Solved with ordinary **sibling containers** (Docker Compose today,
+   Kubernetes-ready later). This is the subject of this chapter.
+2. **Untrusted-content isolation** — sandboxing what [Ornstein](ornstein.md)
+   fetches. Solved with a **microVM-class sandbox** (gVisor / Docker Sandboxes),
+   *not* nested Docker. That is a separate concern, covered under Ornstein's
+   airlock — do not conflate it with the topology here.
+
+Literal Docker-in-Docker was explicitly rejected for isolation: a shared-kernel
+boundary is the wrong tool for untrusted content, and mounting the docker socket
+into the container that handles that content stages a host-root escape.
+
+## What exists today: sibling containers *(shipped)*
+
+`docker/docker-compose.yml` is a single-node topology skeleton. One service is
+real and buildable:
+
+- **`ferric-core`** — the harness and its co-located inference backend
+  (`llama-server`) in **one image** (`docker/Dockerfile`, built with
+  `--features backend-openai`). They are co-located deliberately: ADR-005 pins
+  their link to loopback, so splitting them across a container boundary would break
+  that guarantee without extra network-namespace plumbing. The container mounts a
+  `/workspace` and the shared Animus model store at `/models`.
+
+Other services (a raw `chat` surface, and any future Ornstein service) are present
+only as **commented stubs** marking where later sprints land. There is no docker
+socket mount and no host-published port: when sibling services eventually need to
+reach `ferric-core`, the intended path is an **internal** Docker network, not a
+published port — a decision left to the sprint that operationalizes them.
+
+```sh
+# Build and inspect the current topology:
+docker compose -f docker/docker-compose.yml build ferric-core
+docker compose -f docker/docker-compose.yml config
+```
+
+The model store path is overridable with `MODELS_PATH` in a local, gitignored
+`docker/.env` (see `docker/.env.example`).
+
+## Where this is going: swarming with Kubernetes *(intent)*
+
+The compose topology above is deliberately **k8s-ready** but the Kubernetes layer
+itself is not written. The stated intent, to be built out in a future sprint:
+
+- **A Ferric worker as a schedulable unit.** Package `ferric-core` (harness +
+  co-located backend, loopback pin intact) as a pod that Kubernetes can schedule,
+  replicate, and place on nodes with the right hardware (GPU nodes for larger
+  models, CPU/edge nodes for `Nano`/`Small` tiers).
+- **A swarm of small models over one big one.** This is the thesis at cluster
+  scale: rather than one large model, a *fleet* of small, tier-calibrated Ferric
+  workers, each provably driving its tools, dispatched to tasks matched to its
+  measured tier. The [tier/ring](advanced-tool-rings.md) model is what makes a
+  heterogeneous swarm meaningful — every worker's capability is a measured number,
+  not a guess.
+- **Placement by measured capability.** `model_profiles.json` already records a
+  model's earned tier; the intent is to make that the input to scheduling, so work
+  routes to the smallest worker that can complete it.
+- **Isolation preserved across the swarm.** Ornstein's airlock stays a
+  per-run microVM concern on whichever node runs it; the swarm layer handles
+  deployment and scheduling, never untrusted-content isolation.
+
+None of the above is implemented. It is written here so the design constraints
+that already exist — the loopback pin, the one-image co-location, the
+measured-tier model — are on record for the sprint that builds the swarm, and so
+that intent does not evaporate between now and then.


### PR DESCRIPTION
Assembles the project's documentation into a book with [mdBook](https://rust-lang.github.io/mdBook/) — the same tool behind *The Rust Book*. **Docs-only; no code changes.**

## Approach

`book.toml` sets `src = "docs"`, so **no files were moved**: the existing `docs/` pages stay browsable on GitHub exactly as before, and `docs/SUMMARY.md` sequences them into a book. Build output (`book/`) is gitignored. `mdbook serve --open` for a live preview.

## Structure

```
Why Animus?                          ← the philosophy + honest positioning
├─ Getting Started
├─ Basic Features            query · chat & /do · skills
├─ Advanced Features         tool rings · benchmarking · multimodal · Ornstein
│                            · ICM · MCP & Dark Matter · cron
├─ Advanced Server Config    the inference server (+ installing llama.cpp)
├─ Animus Swarming with K8s  container topology & roadmap
├─ Animus By Example         nine runnable examples + a growing gauntlet
├─ Reference                 commands · configuration · env · credits & citations
└─ Appendix                  the Animus Project components
```

## Notes

- **Current state vs. stated intent is marked inline.** Sections describing unbuilt work — Swarming/K8s (only the compose sibling topology exists), Animus Ophanim, parts of By Example — are flagged as intent, not fact. This is deliberate: the book is meant to hold direction as well as documentation.
- **Introduction** ("Why Animus?") makes the honest case for small-local-model harnessing *without* naming competitors, plus the "simplest = most sophisticated" philosophy and the spine/brain framing.
- **New chapters:** basics (query, chat + `/do`, skills), tool rings, MCP & Dark Matter, Advanced Server Configuration (written against the real `ferric server` surface), Swarming, By Example, Credits & Citations (deps + papers: ReAct, CaMeL, ICM, the lethal trifecta), and an Appendix of the Animus Project components.
- ICM is cited as `docs/icm.md` records it (*Van Clief & McDermott, 2026*).

Builds clean with mdbook v0.5.3 (21 chapters, no broken links).

🤖 Generated with [Claude Code](https://claude.com/claude-code)