### PR TITLE
Restore CI to green after the sprint-113 checkpoint

### DIFF
--- a/crates/ferric-cli/tests/cli.rs
+++ b/crates/ferric-cli/tests/cli.rs
@@ -1096,10 +1096,28 @@ fn write_interrupted_trace_fixture(ws: &std::path::Path, session: &str) -> std::
 }
 
 fn write_clarification_trace_fixture(ws: &std::path::Path) -> std::path::PathBuf {
+    // Generate a REAL needs_input trace by driving the loop with a mock that
+    // asks a clarification question. A hand-built checkpoint cannot be used:
+    // the durable-recovery invariant (sprint 113) requires a stored
+    // RecoveryCheckpoint to equal the projector-derived state anchor, which
+    // only an actual run produces. This mirrors ferric-loop's
+    // `clarification_tests.rs`, but through the on-disk trace the CLI resumes.
     let trace_dir = ws.join(".ferric").join("trace");
     std::fs::create_dir_all(&trace_dir).unwrap();
     let path = trace_dir.join("awaiting-answer.jsonl");
     let mut sink = ferric_trace::JsonlSink::open(&path, "awaiting-answer").unwrap();
+
+    let workspace = ferric_guard::Workspace::new(ws).unwrap();
+    let mut registry = ferric_tools::Registry::new();
+    ferric_tools::register_builtin_tools(&mut registry);
+    let policy = ferric_core::policy_for(&ferric_core::ModelProfile {
+        params_b: 1.0,
+        quant: "Q4_K_M".to_string(),
+        ctx: 4096,
+        family: "test".to_string(),
+        measured_level: None,
+    });
+
     let request = ferric_core::UserInputRequest {
         question: "Which database should this target?".to_string(),
         context: "Both adapters exist and no default is documented.".to_string(),
@@ -1112,63 +1130,41 @@ fn write_clarification_trace_fixture(ws: &std::path::Path) -> std::path::PathBuf
         name: ferric_loop::REQUEST_USER_INPUT.to_string(),
         args: serde_json::to_value(&request).unwrap(),
     }];
-    let state = ferric_trace::RecoveryCheckpointV1 {
-        version: ferric_trace::RECOVERY_CHECKPOINT_VERSION,
-        messages: vec![
-            ferric_core::Message::system("You are Ferric."),
-            ferric_core::Message::user("finish the database task"),
-            assistant,
-            ferric_core::Message::tool_result(
-                "ask-1",
-                "user input requested; session paused until an answer is supplied",
-            ),
-        ],
-        next_turn: 1,
-        last_text: None,
-        head_len: 2,
-        committed_turn_starts: vec![ferric_trace::TurnBoundary {
-            turn: 0,
-            message_index: 2,
-        }],
-        guard_history: Vec::new(),
-        nudged_for_no_action: false,
-        truncated_once: false,
-        last_input_tokens: Some(40),
-        pending_input: Some(request),
-        mutation_epoch: 0,
-        passed_checks: std::collections::BTreeMap::new(),
-    };
-    for event in [
-        ferric_trace::Event::SessionStart {
-            workspace: ws.display().to_string(),
-            resumed_from: None,
-        },
-        ferric_trace::Event::PolicySelected {
-            tier: ferric_core::Tier::Nano,
+    let provider = ferric_provider::MockProvider::new(vec![ferric_provider::Completion {
+        message: assistant,
+        input_tokens: Some(50),
+        output_tokens: Some(10),
+        truncated: false,
+    }]);
+
+    let outcome = futures_executor::block_on(ferric_loop::run(
+        ferric_loop::RunArgs {
+            provider: &provider,
+            registry: &registry,
+            workspace: &workspace,
+            policy: &policy,
             protocol: ferric_core::ActionProtocol::NativeTools,
-            harness_policy: ferric_core::HarnessPolicy::Legacy,
-            max_turns: 15,
-            max_tools: 10,
-            prompt_budget_tokens: 2_800,
-            max_output_tokens: 512,
-            truncation_limit: ferric_core::DEFAULT_TRUNCATION_LIMIT,
-            tier_source: ferric_core::TierSource::Params.label().to_string(),
-        },
-        ferric_trace::Event::SessionPrompt {
-            system: "You are Ferric.".to_string(),
-            user: "finish the database task".to_string(),
+            harness_policy: None,
+            sampling: ferric_provider::SamplingParams::default(),
+            sleeper: &ferric_loop::ThreadSleeper,
+            system_prompt: None,
+            prompt_lineage: None,
             media: Vec::new(),
+            stream_sink: None,
+            resume: None,
+            answer: None,
+            cancel_flag: None,
+            provenance: ferric_guard::Provenance::Clean,
+            sink_policy: ferric_guard::SinkPolicy::deny(),
+            hooks: None,
+            edit_approver: None,
         },
-        ferric_trace::Event::SessionEnd {
-            reason: "needs_input".to_string(),
-        },
-        ferric_trace::Event::RecoveryCheckpoint { state },
-        ferric_trace::Event::SessionPaused {
-            reason: "needs_input".to_string(),
-        },
-    ] {
-        sink.write_event(event).unwrap();
-    }
+        &mut sink,
+        Some("finish the database task"),
+    ))
+    .expect("mock clarification run");
+    assert_eq!(outcome.stop, ferric_loop::StopReason::NeedsInput);
+    drop(sink);
     path
 }
 

--- a/crates/ferric-loop/src/controlled_dispatch.rs
+++ b/crates/ferric-loop/src/controlled_dispatch.rs
@@ -535,7 +535,7 @@ fn path_effect(effect: &WorkspaceEffect) -> Result<PathEffectV1, String> {
 fn file_observation(observation: &FileObservation) -> ObservationV1 {
     let requested_range = (observation.requested.start.is_some()
         || observation.requested.end.is_some())
-    .then(|| RequestedLineRangeV1 {
+    .then_some(RequestedLineRangeV1 {
         start: observation.requested.start,
         end: observation.requested.end,
     });

--- a/crates/ferric-loop/tests/resume_tests.rs
+++ b/crates/ferric-loop/tests/resume_tests.rs
@@ -74,53 +74,56 @@ fn resume_target_inherits_omitted_policy_and_rejects_an_explicit_mismatch() {
 
 #[test]
 fn unavailable_policies_write_no_event_and_dispatch_no_tool() {
-    for policy in [HarnessPolicy::Evidence, HarnessPolicy::EvidencePlanner] {
-        let dir = tempfile::tempdir().unwrap();
-        let workspace = Workspace::new(dir.path()).unwrap();
-        let mut registry = Registry::new();
-        register_builtin_tools(&mut registry);
-        let trace_path = dir.path().join(format!("{}.jsonl", policy.label()));
-        let mut sink = JsonlSink::open(&trace_path, "refused-policy").unwrap();
-        let provider = MockProvider::new(vec![tool_completion(vec![(
-            "tc-0",
-            "write_file",
-            serde_json::json!({"path": "should-not-exist.txt", "content": "no"}),
-        )])]);
-        let sleeper = RecordingSleeper::new();
+    // `Evidence` is now a live policy (sprint 113); only `EvidencePlanner`
+    // remains unavailable and must still be refused by `run()` before any trace
+    // event or tool dispatch. The evidence-runs path is covered positively by
+    // ferric-cli's `evidence_runs_and_planner_fails_before_trace_or_workspace_mutation`.
+    let policy = HarnessPolicy::EvidencePlanner;
+    let dir = tempfile::tempdir().unwrap();
+    let workspace = Workspace::new(dir.path()).unwrap();
+    let mut registry = Registry::new();
+    register_builtin_tools(&mut registry);
+    let trace_path = dir.path().join(format!("{}.jsonl", policy.label()));
+    let mut sink = JsonlSink::open(&trace_path, "refused-policy").unwrap();
+    let provider = MockProvider::new(vec![tool_completion(vec![(
+        "tc-0",
+        "write_file",
+        serde_json::json!({"path": "should-not-exist.txt", "content": "no"}),
+    )])]);
+    let sleeper = RecordingSleeper::new();
 
-        let error = futures_executor::block_on(run(
-            RunArgs {
-                edit_approver: None,
-                cancel_flag: None,
-                sink_policy: ferric_guard::SinkPolicy::deny(),
-                provenance: ferric_guard::Provenance::Clean,
-                provider: &provider,
-                registry: &registry,
-                workspace: &workspace,
-                policy: &nano_policy(),
-                protocol: ActionProtocol::NativeTools,
-                harness_policy: Some(policy),
-                sampling: SamplingParams::default(),
-                sleeper: &sleeper,
-                system_prompt: None,
-                prompt_lineage: None,
-                media: Vec::new(),
-                stream_sink: None,
-                resume: None,
-                answer: None,
-                hooks: None,
-            },
-            &mut sink,
-            Some("write a file"),
-        ))
-        .unwrap_err();
+    let error = futures_executor::block_on(run(
+        RunArgs {
+            edit_approver: None,
+            cancel_flag: None,
+            sink_policy: ferric_guard::SinkPolicy::deny(),
+            provenance: ferric_guard::Provenance::Clean,
+            provider: &provider,
+            registry: &registry,
+            workspace: &workspace,
+            policy: &nano_policy(),
+            protocol: ActionProtocol::NativeTools,
+            harness_policy: Some(policy),
+            sampling: SamplingParams::default(),
+            sleeper: &sleeper,
+            system_prompt: None,
+            prompt_lineage: None,
+            media: Vec::new(),
+            stream_sink: None,
+            resume: None,
+            answer: None,
+            hooks: None,
+        },
+        &mut sink,
+        Some("write a file"),
+    ))
+    .unwrap_err();
 
-        assert!(error.to_string().contains(policy.label()), "{error}");
-        drop(sink);
-        assert_eq!(std::fs::read_to_string(&trace_path).unwrap(), "");
-        assert!(!dir.path().join("should-not-exist.txt").exists());
-        assert!(provider.requests().is_empty());
-    }
+    assert!(error.to_string().contains(policy.label()), "{error}");
+    drop(sink);
+    assert_eq!(std::fs::read_to_string(&trace_path).unwrap(), "");
+    assert!(!dir.path().join("should-not-exist.txt").exists());
+    assert!(provider.requests().is_empty());
 }
 
 #[test]

--- a/crates/ferric-tools/src/builtin/controlled_file.rs
+++ b/crates/ferric-tools/src/builtin/controlled_file.rs
@@ -1908,7 +1908,12 @@ fn logical_target(
     workspace: &Workspace,
     requested_path: &str,
 ) -> Result<(String, PathBuf), PrepareError> {
-    let requested = Path::new(requested_path);
+    // A model may emit either path separator regardless of host OS. Treat a
+    // backslash as a component separator so Linux resolves `dir\file` the same
+    // way Windows already does, matching the forward-slash canonical form this
+    // function returns below.
+    let requested_path = requested_path.replace('\\', "/");
+    let requested = Path::new(&requested_path);
     let relative = if requested.is_absolute() {
         requested.strip_prefix(workspace.root()).map_err(|_| {
             PrepareError::new(

--- a/crates/ferric-tools/src/builtin/controlled_read.rs
+++ b/crates/ferric-tools/src/builtin/controlled_read.rs
@@ -53,11 +53,14 @@ fn open_controlled_dir_with<F>(
 where
     F: FnOnce(),
 {
+    // Normalize model-supplied separators before the boundary check so a
+    // backslash path is resolved (and escape-checked) identically on every OS.
+    let requested = requested.replace('\\', "/");
     workspace
-        .resolve(requested)
+        .resolve(&requested)
         .map_err(|error| format!("boundary: {error}"))?;
     after_boundary_check();
-    let relative = lexical_relative(workspace, Path::new(requested))?;
+    let relative = lexical_relative(workspace, Path::new(&requested))?;
     let dir = open_relative_dir(workspace, &relative)?;
     Ok((dir, relative))
 }
@@ -77,11 +80,14 @@ fn read_controlled_file_with<F>(
 where
     F: FnOnce(),
 {
+    // Normalize model-supplied separators before the boundary check so a
+    // backslash path is resolved (and escape-checked) identically on every OS.
+    let requested = requested.replace('\\', "/");
     workspace
-        .resolve(requested)
+        .resolve(&requested)
         .map_err(|error| format!("boundary: {error}"))?;
     after_boundary_check();
-    let relative = lexical_relative(workspace, Path::new(requested))?;
+    let relative = lexical_relative(workspace, Path::new(&requested))?;
     let leaf = relative
         .file_name()
         .ok_or_else(|| "controlled read path must name a file".to_string())?


### PR DESCRIPTION
Restores `main` to green after the sprint-113 checkpoint (`841bf3a`) merged with CI red.

## Fixes (each verified)
- **clippy `then_some`** (`controlled_dispatch.rs`) — the single `-D warnings` error that gated all three CI jobs before any test ran.
- **Cross-platform paths** — controlled read/navigate/mutate normalize `\`→`/` in the model-supplied path before the boundary check, so a Windows-style path resolves (and is escape-checked) identically on Linux. Fixes the two `controlled_navigation` tests that only passed where `\` is already a separator.
- **clarification_resume fixture** — now generates a real `needs_input` trace via `ferric_loop::run` instead of a hand-built checkpoint that the durable-recovery parity invariant (correctly) rejects.
- **resume_tests** — `evidence` is a live policy now; only `evidence_planner` stays unavailable.

## Verification
- `cargo fmt --check` clean; `cargo clippy --all-targets -D warnings` clean (default and `--features backend-openai`).
- Full workspace suite green on **Windows (887 tests)**; `ferric-tools` green on **Linux (WSL)** including both formerly-Linux-only failures.
- Live demo re-validated: real `qwen2.5-coder-7b` drove the constrained loop to `E2E PASS` (legacy path).

## Not in this PR
Sprint-113 **T-11307** (real-model paired causal evaluation) is deliberately deferred — it is multi-day and not required for the demo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)