### PR TITLE
Make evidence mode usable: structural filesystem operations

### DIFF
--- a/agent-tasks/agent-tasks.md
+++ b/agent-tasks/agent-tasks.md
@@ -211,3 +211,24 @@ intervention through repository-native Rust, tests, runtime evidence, and Git.
   evidence-only result, freeze a planner orchestration addendum or reject the
   arm; record the causal conclusion, ADR, verification report, commit/push/PR,
   and CI.
+
+## Sprint 113 follow-up — evidence mode made usable for structural ops
+- [x] **Structural filesystem ops under evidence control.** A live 7B run
+  exposed that `--harness-policy evidence` excluded every structural tool
+  (`make_dir`/`delete_path`/`move_path`/`copy_file` were `Opaque`), so it could
+  not create a directory — the model hit "unsupported controlled mutation
+  target" and gave up. Now each declares `ContentMutation` + a typed `prepare()`:
+  `copy_file` reuses the content-mutation commit (candidate = source bytes); the
+  other three use a new `commit_path_mutation` that CASes the prepared
+  precondition through a capability-pinned parent and records **measured,
+  directory-aware** effects (new `PathEffectKind::{CreatedDirectory,
+  DeletedDirectory}`). The controller's `mutation_block` now accepts a `Directory`
+  precondition (existence/type CAS, no content evidence required),
+  `validate_workspace_effect_shape` accepts the dir kinds, and
+  `trace_structure`'s effect-tool allowlist covers the structural tools. **Live:
+  the exact failing task now completes** (create `proj` + `proj/calc.py` +
+  create/delete `scratch`) with `task_complete`, correct artifacts, 2
+  `created_directory` + 1 `deleted_directory` trace effects, and a clean
+  side-effect-free `trace verify`. Deferred: recursive non-empty-directory
+  delete; implicit `move_path` overwrite; `shell_exec`/`git_*` stay opaque by
+  design.

--- a/crates/ferric-loop/src/controlled_dispatch.rs
+++ b/crates/ferric-loop/src/controlled_dispatch.rs
@@ -494,14 +494,18 @@ fn path_effect(effect: &WorkspaceEffect) -> Result<PathEffectV1, String> {
         WorkspaceEffectKind::Created => PathEffectKind::Created,
         WorkspaceEffectKind::Modified => PathEffectKind::Modified,
         WorkspaceEffectKind::Deleted => PathEffectKind::Deleted,
+        WorkspaceEffectKind::CreatedDirectory => PathEffectKind::CreatedDirectory,
+        WorkspaceEffectKind::DeletedDirectory => PathEffectKind::DeletedDirectory,
         WorkspaceEffectKind::Opaque => {
             return Err(format!("workspace effect for {:?} is opaque", effect.path));
         }
     };
+    // A directory carries no content digest; it is a valid structural preimage
+    // or postimage, distinguished from a file by the effect `kind` above.
     let before_sha256 = match &effect.before {
-        PathState::Absent => None,
+        PathState::Absent | PathState::Directory => None,
         PathState::File { sha256, .. } => Some(sha256.clone()),
-        PathState::Directory | PathState::Other => {
+        PathState::Other => {
             return Err(format!(
                 "workspace effect for {:?} has a non-file preimage",
                 effect.path
@@ -509,13 +513,13 @@ fn path_effect(effect: &WorkspaceEffect) -> Result<PathEffectV1, String> {
         }
     };
     let (after_sha256, after_bytes, after_lines) = match &effect.after {
-        PathState::Absent => (None, None, None),
+        PathState::Absent | PathState::Directory => (None, None, None),
         PathState::File {
             sha256,
             bytes,
             lines,
         } => (Some(sha256.clone()), Some(*bytes), Some(*lines)),
-        PathState::Directory | PathState::Other => {
+        PathState::Other => {
             return Err(format!(
                 "workspace effect for {:?} has a non-file postimage",
                 effect.path

--- a/crates/ferric-loop/src/controller.rs
+++ b/crates/ferric-loop/src/controller.rs
@@ -212,9 +212,12 @@ impl ControllerState {
         let mut seen = BTreeSet::new();
         for requirement in requirements {
             let unsupported_identity = match &requirement.current {
-                PreparedPathIdentityV1::Absent => false,
+                // A directory precondition is a valid existence/type CAS with no
+                // content to observe; only a non-file, non-directory occupant
+                // (symlink, device, …) is unsupported.
+                PreparedPathIdentityV1::Absent | PreparedPathIdentityV1::Directory => false,
                 PreparedPathIdentityV1::File { sha256, .. } => !is_sha256(sha256),
-                PreparedPathIdentityV1::Directory | PreparedPathIdentityV1::Other => true,
+                PreparedPathIdentityV1::Other => true,
             };
             if validate_workspace_path(&requirement.path).is_err()
                 || !seen.insert(requirement.path.as_str())
@@ -255,10 +258,12 @@ impl ControllerState {
         }
         for requirement in requirements {
             let (current_sha256, current_bytes) = match &requirement.current {
-                PreparedPathIdentityV1::Absent => continue,
+                // Absent (create) and Directory (structural) preconditions carry
+                // no content-observation requirement.
+                PreparedPathIdentityV1::Absent | PreparedPathIdentityV1::Directory => continue,
                 PreparedPathIdentityV1::File { sha256, bytes } => (sha256.as_str(), *bytes),
-                PreparedPathIdentityV1::Directory | PreparedPathIdentityV1::Other => {
-                    unreachable!("unsupported identities returned above")
+                PreparedPathIdentityV1::Other => {
+                    unreachable!("Other identities are blocked above")
                 }
             };
             let Some(evidence) = self.file_evidence.get(&requirement.path) else {
@@ -1365,6 +1370,14 @@ fn validate_workspace_effect_shape(
                     path_effect.path
                 )));
             }
+            PathEffectKind::CreatedDirectory | PathEffectKind::DeletedDirectory
+                if path_effect.before_sha256.is_some() || path_effect.after_sha256.is_some() =>
+            {
+                return Err(ControllerError::invalid(format!(
+                    "directory effect {:?} must not carry a content digest",
+                    path_effect.path
+                )));
+            }
             PathEffectKind::Opaque => {
                 return Err(ControllerError::invalid(format!(
                     "opaque path effect {:?} is unverifiable",
@@ -2084,6 +2097,54 @@ mod tests {
                 PreparedPathIdentityV1::Absent,
             )
             .is_err()
+        );
+    }
+
+    #[test]
+    fn directory_preconditions_and_effects_need_no_content_evidence() {
+        let mut state = evidence_state();
+        // A directory precondition is admitted with no prior file observation:
+        // a directory has no content to have read first.
+        let requirement = MutationRequirement {
+            path: "temp".to_string(),
+            current: PreparedPathIdentityV1::Directory,
+        };
+        assert!(state.mutation_block(1, &[requirement]).is_none());
+
+        // A measured directory creation advances the epoch and records no file
+        // evidence.
+        let created_dir = WorkspaceEffectV1 {
+            version: CONTROLLER_RECORD_VERSION,
+            mutation_epoch: 1,
+            effects: vec![PathEffectV1 {
+                path: "proj".to_string(),
+                kind: PathEffectKind::CreatedDirectory,
+                before_sha256: None,
+                after_sha256: None,
+                after_bytes: None,
+                after_lines: None,
+            }],
+        };
+        state.apply_workspace_effect(1, &created_dir).unwrap();
+        assert_eq!(state.mutation_epoch(), 1);
+
+        // A directory effect that carries a content digest is rejected.
+        let digest_on_directory = WorkspaceEffectV1 {
+            version: CONTROLLER_RECORD_VERSION,
+            mutation_epoch: 2,
+            effects: vec![PathEffectV1 {
+                path: "proj".to_string(),
+                kind: PathEffectKind::DeletedDirectory,
+                before_sha256: Some(sha('a')),
+                after_sha256: None,
+                after_bytes: None,
+                after_lines: None,
+            }],
+        };
+        assert!(
+            state
+                .apply_workspace_effect(1, &digest_on_directory)
+                .is_err()
         );
     }
 

--- a/crates/ferric-loop/src/trace_structure.rs
+++ b/crates/ferric-loop/src/trace_structure.rs
@@ -425,7 +425,7 @@ impl TraceStructure {
         effect: &WorkspaceEffectV1,
     ) -> Result<(), String> {
         self.ensure_evidence_harness("WorkspaceEffectRecorded")?;
-        if !is_single_target_content_tool(tool) {
+        if !is_effect_recording_tool(tool) {
             return Err(format!(
                 "WorkspaceEffectRecorded({call_id}) uses unsupported effect tool {tool:?}"
             ));
@@ -1578,6 +1578,14 @@ fn is_single_target_content_tool(name: &str) -> bool {
     )
 }
 
+/// Every tool that may legitimately record a measured `WorkspaceEffectRecorded`:
+/// the single-target content mutations plus the structural mutations. Effect
+/// paths are still validated against each call's statically known targets.
+fn is_effect_recording_tool(name: &str) -> bool {
+    is_single_target_content_tool(name)
+        || matches!(name, "make_dir" | "delete_path" | "move_path" | "copy_file")
+}
+
 fn statically_known_call_targets(call: &ToolCall) -> Result<Option<BTreeSet<String>>, String> {
     let keys: &[&str] = match call.name.as_str() {
         "write_file" | "edit_file" | "multi_edit" | "apply_patch" | "delete_path" | "make_dir" => {
@@ -1924,6 +1932,18 @@ mod tests {
                 ),
             },
         }
+    }
+
+    #[test]
+    fn structural_mutations_are_effect_recording_tools() {
+        for name in ["make_dir", "delete_path", "move_path", "copy_file"] {
+            assert!(is_effect_recording_tool(name), "{name}");
+        }
+        // Content mutations remain effect-recording; a read-only navigation and
+        // an opaque tool are not.
+        assert!(is_effect_recording_tool("write_file"));
+        assert!(!is_effect_recording_tool("search_files"));
+        assert!(!is_effect_recording_tool("shell_exec"));
     }
 
     #[test]

--- a/crates/ferric-loop/tests/evidence_dispatch_tests.rs
+++ b/crates/ferric-loop/tests/evidence_dispatch_tests.rs
@@ -315,7 +315,10 @@ fn full_evidence_path_reads_edits_repairs_verifies_and_completes() {
         })
         .unwrap();
     assert!(offered.iter().any(|name| name == "run_check"));
-    for opaque in ["shell_exec", "git_write", "move_path", "delete_path"] {
+    // Structural mutations (make_dir/delete_path/move_path/copy_file) are now
+    // typed and offered under evidence control; only genuinely opaque Write/
+    // Execute tools stay excluded.
+    for opaque in ["shell_exec", "git_write"] {
         assert!(!offered.iter().any(|name| name == opaque), "{offered:?}");
     }
     validate_trace(&capture.records);

--- a/crates/ferric-tools/src/builtin/controlled_file.rs
+++ b/crates/ferric-tools/src/builtin/controlled_file.rs
@@ -15,9 +15,9 @@ use ferric_guard::Workspace;
 use crate::control::{
     CandidatePathState, ControlFailure, ControlFailureKind, ControlFailureWitness,
     FileMutationCandidate, MutationIntent, MutationKind, NoEffectKind, ObservationRequirement,
-    PathState, PrepareCtx, PrepareError, PrepareErrorKind, PrepareFailureWitness,
-    StaleObservationWitness, ToolPreparation, UnsupportedMutationKind, WorkspaceEffect,
-    WorkspaceEffectKind, WorkspaceEffectReport, logical_line_count, sha256_bytes,
+    PathMutationCandidate, PathState, PrepareCtx, PrepareError, PrepareErrorKind,
+    PrepareFailureWitness, StaleObservationWitness, ToolPreparation, UnsupportedMutationKind,
+    WorkspaceEffect, WorkspaceEffectKind, WorkspaceEffectReport, logical_line_count, sha256_bytes,
 };
 
 use super::check_syntax::candidate_syntax_transition;
@@ -252,6 +252,243 @@ pub(crate) fn compile_candidate(
     Ok(ToolPreparation::file_mutation(intent, operation))
 }
 
+/// Observe a controlled target's current nofollow state without rejecting
+/// directories (unlike [`inspect_for_prepare`], which only admits files).
+/// Returns the normalized workspace-relative path and its `PathState`.
+fn inspect_path_state(
+    ctx: &PrepareCtx<'_>,
+    requested_path: &str,
+) -> Result<(String, PathState), PrepareError> {
+    let (path, absolute) = logical_target(ctx.workspace, requested_path)?;
+    let parent = pin_parent(ctx.workspace, &absolute)
+        .map_err(|failure| unsupported_path_error(&path, failure.message))?;
+    let observed = observe_target(&parent)
+        .map_err(|message| PrepareError::new(PrepareErrorKind::Io, message))?;
+    if let Some(reason) = observed.unsupported_reason {
+        return Err(unsupported_path_error(&path, reason));
+    }
+    Ok((path, observed.state))
+}
+
+fn structural_mutation_intent(
+    kind: MutationKind,
+    states: Vec<CandidatePathState>,
+) -> MutationIntent {
+    let requirements = states
+        .iter()
+        .filter_map(|state| match &state.before {
+            PathState::File { sha256, .. } => Some(ObservationRequirement {
+                path: state.path.clone(),
+                sha256: sha256.clone(),
+            }),
+            _ => None,
+        })
+        .collect();
+    MutationIntent {
+        kind,
+        requirements,
+        paths: states.iter().map(|state| state.path.clone()).collect(),
+        states,
+        syntax: None,
+    }
+}
+
+fn directory_is_empty(ctx: &PrepareCtx<'_>, path: &str) -> Result<bool, PrepareError> {
+    let absolute = ctx.workspace.root().join(Path::new(path));
+    let parent = pin_parent(ctx.workspace, &absolute)
+        .map_err(|failure| unsupported_path_error(path, failure.message))?;
+    let mut entries = parent.dir().read_dir(&parent.leaf).map_err(|error| {
+        PrepareError::new(
+            PrepareErrorKind::Io,
+            format!("inspect directory {path}: {error}"),
+        )
+    })?;
+    Ok(entries.next().is_none())
+}
+
+/// `make_dir` under evidence control: create a new directory. An existing
+/// directory is a no-effect; any other occupant is unsupported.
+pub(crate) fn prepare_make_dir(
+    ctx: &PrepareCtx<'_>,
+    path_arg: &str,
+) -> Result<ToolPreparation, PrepareError> {
+    let (path, state) = inspect_path_state(ctx, path_arg)?;
+    match state {
+        PathState::Absent => {
+            let states = vec![CandidatePathState {
+                path: path.clone(),
+                before: PathState::Absent,
+                candidate: PathState::Directory,
+            }];
+            let intent = structural_mutation_intent(MutationKind::CreateDirectory, states);
+            Ok(ToolPreparation::path_mutation(
+                intent,
+                PathMutationCandidate::CreateDir {
+                    path: path.clone(),
+                    success: format!("created directory {path}"),
+                },
+            ))
+        }
+        PathState::Directory => Err(no_effect_error(
+            NoEffectKind::Identity,
+            CandidatePathState {
+                path: path.clone(),
+                before: PathState::Directory,
+                candidate: PathState::Directory,
+            },
+            format!("directory already exists: {path}"),
+        )),
+        PathState::File { .. } | PathState::Other => Err(unsupported_path_error(
+            &path,
+            format!("{path} already exists and is not a directory"),
+        )),
+    }
+}
+
+/// `delete_path` under evidence control: remove a regular file, or an **empty**
+/// directory. A non-empty directory is unsupported (empty it first); an absent
+/// path is a no-effect.
+pub(crate) fn prepare_delete(
+    ctx: &PrepareCtx<'_>,
+    path_arg: &str,
+) -> Result<ToolPreparation, PrepareError> {
+    let (path, state) = inspect_path_state(ctx, path_arg)?;
+    match state {
+        PathState::Absent => Err(no_effect_error(
+            NoEffectKind::MatchNotFound,
+            CandidatePathState {
+                path: path.clone(),
+                before: PathState::Absent,
+                candidate: PathState::Absent,
+            },
+            format!("path not found: {path}"),
+        )),
+        PathState::File { .. } => {
+            let states = vec![CandidatePathState {
+                path: path.clone(),
+                before: state.clone(),
+                candidate: PathState::Absent,
+            }];
+            let intent = structural_mutation_intent(MutationKind::DeleteFile, states);
+            Ok(ToolPreparation::path_mutation(
+                intent,
+                PathMutationCandidate::Delete {
+                    path: path.clone(),
+                    expected: state,
+                    success: format!("deleted file {path}"),
+                },
+            ))
+        }
+        PathState::Directory => {
+            if !directory_is_empty(ctx, &path)? {
+                return Err(unsupported_path_error(
+                    &path,
+                    format!("directory {path} is not empty; delete its contents first"),
+                ));
+            }
+            let states = vec![CandidatePathState {
+                path: path.clone(),
+                before: PathState::Directory,
+                candidate: PathState::Absent,
+            }];
+            let intent = structural_mutation_intent(MutationKind::DeleteDirectory, states);
+            Ok(ToolPreparation::path_mutation(
+                intent,
+                PathMutationCandidate::Delete {
+                    path: path.clone(),
+                    expected: PathState::Directory,
+                    success: format!("deleted directory {path}"),
+                },
+            ))
+        }
+        PathState::Other => Err(unsupported_path_error(
+            &path,
+            format!("{path} is not a regular file or directory"),
+        )),
+    }
+}
+
+/// `move_path` under evidence control: rename a file or directory to an absent
+/// destination (no implicit overwrite).
+pub(crate) fn prepare_move(
+    ctx: &PrepareCtx<'_>,
+    from_arg: &str,
+    to_arg: &str,
+) -> Result<ToolPreparation, PrepareError> {
+    let (from, from_state) = inspect_path_state(ctx, from_arg)?;
+    let (to, to_state) = inspect_path_state(ctx, to_arg)?;
+    match &from_state {
+        PathState::Absent => Err(no_effect_error(
+            NoEffectKind::MatchNotFound,
+            CandidatePathState {
+                path: from.clone(),
+                before: PathState::Absent,
+                candidate: PathState::Absent,
+            },
+            format!("source not found: {from}"),
+        )),
+        PathState::Other => Err(unsupported_path_error(
+            &from,
+            format!("source {from} is not a regular file or directory"),
+        )),
+        PathState::File { .. } | PathState::Directory => {
+            if !matches!(to_state, PathState::Absent) {
+                return Err(unsupported_path_error(
+                    &to,
+                    format!("destination {to} already exists; move does not overwrite"),
+                ));
+            }
+            let destination_state = match &from_state {
+                PathState::File { .. } => from_state.clone(),
+                PathState::Directory => PathState::Directory,
+                _ => unreachable!("source state already narrowed to file or directory"),
+            };
+            let states = vec![
+                CandidatePathState {
+                    path: from.clone(),
+                    before: from_state.clone(),
+                    candidate: PathState::Absent,
+                },
+                CandidatePathState {
+                    path: to.clone(),
+                    before: PathState::Absent,
+                    candidate: destination_state,
+                },
+            ];
+            let intent = structural_mutation_intent(MutationKind::MovePath, states);
+            Ok(ToolPreparation::path_mutation(
+                intent,
+                PathMutationCandidate::Move {
+                    from: from.clone(),
+                    from_expected: from_state,
+                    to: to.clone(),
+                    success: format!("moved {from} -> {to}"),
+                },
+            ))
+        }
+    }
+}
+
+/// `copy_file` under evidence control: publish the source bytes at the
+/// destination, reusing the content-mutation commit (atomic write, CAS, and the
+/// read-before-overwrite requirement when the destination already exists).
+pub(crate) fn prepare_copy(
+    ctx: &PrepareCtx<'_>,
+    from_arg: &str,
+    to_arg: &str,
+) -> Result<ToolPreparation, PrepareError> {
+    let source = inspect_for_prepare(ctx, from_arg, false)?;
+    let bytes = source.bytes.clone().ok_or_else(|| {
+        PrepareError::new(
+            PrepareErrorKind::Io,
+            format!("copy: source {} has no readable bytes", source.path),
+        )
+    })?;
+    let destination = inspect_for_prepare(ctx, to_arg, true)?;
+    let success = format!("copied {} -> {}", source.path, destination.path);
+    compile_candidate(destination, bytes, NoEffectKind::Identity, success)
+}
+
 /// Publish exact candidate bytes through a fresh inode under a capability-pinned
 /// parent. Existing inodes are never modified, so hard-link aliases cannot turn
 /// a workspace edit into an out-of-workspace write. Directory and leaf identity
@@ -270,6 +507,184 @@ pub(crate) fn commit_candidate(
         |_, _| {},
         |_| {},
     )
+}
+
+/// Commit a structural (non-content) mutation: create/remove a directory,
+/// remove a regular file, or rename a path. Each leaf is re-observed through a
+/// capability-pinned parent immediately before the operation and CAS-checked
+/// against the prepared precondition, so a state change between preparation and
+/// commit is reported as a stale precondition rather than acted on blindly.
+pub(crate) fn commit_path_mutation(
+    workspace: &Workspace,
+    candidate: PathMutationCandidate,
+) -> FileCommitResult {
+    match candidate {
+        PathMutationCandidate::CreateDir { path, success } => {
+            let parent = match cas_leaf(workspace, &path, &PathState::Absent) {
+                Ok(parent) => parent,
+                Err(result) => return *result,
+            };
+            match parent.dir().create_dir(&parent.leaf) {
+                Ok(()) => path_success(&path, PathState::Absent, PathState::Directory, success),
+                Err(error) => failure_result(
+                    ControlFailureKind::Io,
+                    format!("create directory {path}: {error}"),
+                    None,
+                    Vec::new(),
+                ),
+            }
+        }
+        PathMutationCandidate::Delete {
+            path,
+            expected,
+            success,
+        } => {
+            let parent = match cas_leaf(workspace, &path, &expected) {
+                Ok(parent) => parent,
+                Err(result) => return *result,
+            };
+            let outcome = match &expected {
+                PathState::File { .. } => parent.dir().remove_file(&parent.leaf),
+                PathState::Directory => parent.dir().remove_dir(&parent.leaf),
+                PathState::Absent | PathState::Other => {
+                    return failure_result(
+                        ControlFailureKind::Io,
+                        format!("delete {path}: unsupported prepared state"),
+                        None,
+                        Vec::new(),
+                    );
+                }
+            };
+            match outcome {
+                Ok(()) => path_success(&path, expected, PathState::Absent, success),
+                Err(error)
+                    if matches!(expected, PathState::Directory)
+                        && error.kind() == ErrorKind::DirectoryNotEmpty =>
+                {
+                    stale_result(
+                        path,
+                        PathState::Directory,
+                        PathState::Directory,
+                        format!("directory is no longer empty: {error}"),
+                    )
+                }
+                Err(error) => failure_result(
+                    ControlFailureKind::Io,
+                    format!("delete {path}: {error}"),
+                    None,
+                    Vec::new(),
+                ),
+            }
+        }
+        PathMutationCandidate::Move {
+            from,
+            from_expected,
+            to,
+            success,
+        } => {
+            let from_parent = match cas_leaf(workspace, &from, &from_expected) {
+                Ok(parent) => parent,
+                Err(result) => return *result,
+            };
+            let to_parent = match cas_leaf(workspace, &to, &PathState::Absent) {
+                Ok(parent) => parent,
+                Err(result) => return *result,
+            };
+            match from_parent
+                .dir()
+                .rename(&from_parent.leaf, to_parent.dir(), &to_parent.leaf)
+            {
+                Ok(()) => {
+                    let effects = vec![
+                        structural_effect(&from, from_expected.clone(), PathState::Absent),
+                        structural_effect(&to, PathState::Absent, from_expected),
+                    ];
+                    FileCommitResult {
+                        full: success,
+                        is_error: false,
+                        effects: WorkspaceEffectReport::Measured(effects),
+                        failure: None,
+                    }
+                }
+                Err(error) => failure_result(
+                    ControlFailureKind::Io,
+                    format!("move {from} -> {to}: {error}"),
+                    None,
+                    Vec::new(),
+                ),
+            }
+        }
+    }
+}
+
+/// Pin the leaf's parent and re-observe the leaf, requiring it to match the
+/// prepared `expected` state (a nofollow existence/type/content CAS). Any
+/// mismatch — including a vanished parent — is a stale precondition.
+fn cas_leaf(
+    workspace: &Workspace,
+    path: &str,
+    expected: &PathState,
+) -> Result<PinnedParent, Box<FileCommitResult>> {
+    let absolute = workspace.root().join(Path::new(path));
+    let parent = pin_parent(workspace, &absolute).map_err(|failure| {
+        Box::new(stale_result(
+            path.to_string(),
+            expected.clone(),
+            failure.observed,
+            failure.message,
+        ))
+    })?;
+    let observed = observe_target(&parent).map_err(|message| {
+        Box::new(failure_result(
+            ControlFailureKind::Io,
+            message,
+            None,
+            Vec::new(),
+        ))
+    })?;
+    if observed.unsupported_reason.is_some() || &observed.state != expected {
+        return Err(Box::new(stale_result(
+            path.to_string(),
+            expected.clone(),
+            observed.state,
+            observed
+                .unsupported_reason
+                .unwrap_or_else(|| "target state changed after preparation".to_string()),
+        )));
+    }
+    Ok(parent)
+}
+
+fn path_success(
+    path: &str,
+    before: PathState,
+    after: PathState,
+    success: String,
+) -> FileCommitResult {
+    FileCommitResult {
+        full: success,
+        is_error: false,
+        effects: WorkspaceEffectReport::Measured(vec![structural_effect(path, before, after)]),
+        failure: None,
+    }
+}
+
+/// Classify a structural before/after transition. Unlike [`measured_effects`],
+/// this understands directory entries.
+fn structural_effect(path: &str, before: PathState, after: PathState) -> WorkspaceEffect {
+    let kind = match (&before, &after) {
+        (PathState::Absent, PathState::Directory) => WorkspaceEffectKind::CreatedDirectory,
+        (PathState::Directory, PathState::Absent) => WorkspaceEffectKind::DeletedDirectory,
+        (PathState::Absent, PathState::File { .. }) => WorkspaceEffectKind::Created,
+        (PathState::File { .. }, PathState::Absent) => WorkspaceEffectKind::Deleted,
+        _ => WorkspaceEffectKind::Opaque,
+    };
+    WorkspaceEffect {
+        path: path.to_string(),
+        kind,
+        before,
+        after,
+    }
 }
 
 fn commit_candidate_with<F, G, H, I>(

--- a/crates/ferric-tools/src/builtin/copy_file.rs
+++ b/crates/ferric-tools/src/builtin/copy_file.rs
@@ -2,6 +2,9 @@ use serde_json::json;
 
 use ferric_guard::PermissionLevel;
 
+use crate::control::{
+    ControlCapability, PrepareCtx, PrepareError, PrepareErrorKind, ToolPreparation,
+};
 use crate::spec::{Tool, ToolCtx, ToolSpec};
 
 /// Copy a file within the workspace. BOTH endpoints are declared as target paths
@@ -37,6 +40,36 @@ impl Tool for CopyFile {
             .iter()
             .filter_map(|k| args.get(*k).and_then(|v| v.as_str()).map(String::from))
             .collect()
+    }
+
+    fn control_capability(&self) -> ControlCapability {
+        ControlCapability::ContentMutation
+    }
+
+    fn prepare(
+        &self,
+        ctx: &PrepareCtx<'_>,
+        args: &serde_json::Value,
+    ) -> Result<ToolPreparation, PrepareError> {
+        let from = args
+            .get("from")
+            .and_then(|value| value.as_str())
+            .ok_or_else(|| {
+                PrepareError::new(
+                    PrepareErrorKind::InvalidArguments,
+                    "missing required string argument: from",
+                )
+            })?;
+        let to = args
+            .get("to")
+            .and_then(|value| value.as_str())
+            .ok_or_else(|| {
+                PrepareError::new(
+                    PrepareErrorKind::InvalidArguments,
+                    "missing required string argument: to",
+                )
+            })?;
+        super::controlled_file::prepare_copy(ctx, from, to)
     }
 
     fn run(&self, ctx: &ToolCtx<'_>, args: &serde_json::Value) -> Result<String, String> {

--- a/crates/ferric-tools/src/builtin/delete_path.rs
+++ b/crates/ferric-tools/src/builtin/delete_path.rs
@@ -2,6 +2,9 @@ use serde_json::json;
 
 use ferric_guard::PermissionLevel;
 
+use crate::control::{
+    ControlCapability, PrepareCtx, PrepareError, PrepareErrorKind, ToolPreparation,
+};
 use crate::spec::{Tool, ToolCtx, ToolSpec};
 
 use super::path_arg;
@@ -30,6 +33,20 @@ impl Tool for DeletePath {
             permission: PermissionLevel::Write,
             ring: 0,
         }
+    }
+
+    fn control_capability(&self) -> ControlCapability {
+        ControlCapability::ContentMutation
+    }
+
+    fn prepare(
+        &self,
+        ctx: &PrepareCtx<'_>,
+        args: &serde_json::Value,
+    ) -> Result<ToolPreparation, PrepareError> {
+        let path = path_arg(args)
+            .map_err(|message| PrepareError::new(PrepareErrorKind::InvalidArguments, message))?;
+        super::controlled_file::prepare_delete(ctx, path)
     }
 
     fn run(&self, ctx: &ToolCtx<'_>, args: &serde_json::Value) -> Result<String, String> {

--- a/crates/ferric-tools/src/builtin/make_dir.rs
+++ b/crates/ferric-tools/src/builtin/make_dir.rs
@@ -2,6 +2,9 @@ use serde_json::json;
 
 use ferric_guard::PermissionLevel;
 
+use crate::control::{
+    ControlCapability, PrepareCtx, PrepareError, PrepareErrorKind, ToolPreparation,
+};
 use crate::spec::{Tool, ToolCtx, ToolSpec};
 
 use super::path_arg;
@@ -26,6 +29,20 @@ impl Tool for MakeDir {
             permission: PermissionLevel::Write,
             ring: 0,
         }
+    }
+
+    fn control_capability(&self) -> ControlCapability {
+        ControlCapability::ContentMutation
+    }
+
+    fn prepare(
+        &self,
+        ctx: &PrepareCtx<'_>,
+        args: &serde_json::Value,
+    ) -> Result<ToolPreparation, PrepareError> {
+        let path = path_arg(args)
+            .map_err(|message| PrepareError::new(PrepareErrorKind::InvalidArguments, message))?;
+        super::controlled_file::prepare_make_dir(ctx, path)
     }
 
     fn run(&self, ctx: &ToolCtx<'_>, args: &serde_json::Value) -> Result<String, String> {

--- a/crates/ferric-tools/src/builtin/move_path.rs
+++ b/crates/ferric-tools/src/builtin/move_path.rs
@@ -2,7 +2,21 @@ use serde_json::json;
 
 use ferric_guard::PermissionLevel;
 
+use crate::control::{
+    ControlCapability, PrepareCtx, PrepareError, PrepareErrorKind, ToolPreparation,
+};
 use crate::spec::{Tool, ToolCtx, ToolSpec};
+
+fn required_str<'a>(args: &'a serde_json::Value, key: &str) -> Result<&'a str, PrepareError> {
+    args.get(key)
+        .and_then(|value| value.as_str())
+        .ok_or_else(|| {
+            PrepareError::new(
+                PrepareErrorKind::InvalidArguments,
+                format!("missing required string argument: {key}"),
+            )
+        })
+}
 
 /// Move/rename a file or directory within the workspace. BOTH endpoints are
 /// declared as target paths so the registry boundary-checks each before the
@@ -37,6 +51,20 @@ impl Tool for MovePath {
             .iter()
             .filter_map(|k| args.get(*k).and_then(|v| v.as_str()).map(String::from))
             .collect()
+    }
+
+    fn control_capability(&self) -> ControlCapability {
+        ControlCapability::ContentMutation
+    }
+
+    fn prepare(
+        &self,
+        ctx: &PrepareCtx<'_>,
+        args: &serde_json::Value,
+    ) -> Result<ToolPreparation, PrepareError> {
+        let from = required_str(args, "from")?;
+        let to = required_str(args, "to")?;
+        super::controlled_file::prepare_move(ctx, from, to)
     }
 
     fn run(&self, ctx: &ToolCtx<'_>, args: &serde_json::Value) -> Result<String, String> {

--- a/crates/ferric-tools/src/control.rs
+++ b/crates/ferric-tools/src/control.rs
@@ -290,6 +290,10 @@ pub enum WorkspaceEffectKind {
     Created,
     Modified,
     Deleted,
+    /// A directory was created (structural mutation; no content digest).
+    CreatedDirectory,
+    /// An (empty) directory was removed (structural mutation; no content digest).
+    DeletedDirectory,
     Opaque,
 }
 
@@ -370,6 +374,7 @@ pub(crate) enum PreparedExecution {
         failure: Option<ControlFailure>,
     },
     FileMutation(FileMutationCandidate),
+    PathMutation(PathMutationCandidate),
 }
 
 /// Exact bytes and CAS identity sealed inside a [`ToolPreparation`].
@@ -378,6 +383,30 @@ pub(crate) struct FileMutationCandidate {
     pub expected: PathState,
     pub candidate: Vec<u8>,
     pub success: String,
+}
+
+/// A structural (non-content) mutation sealed inside a [`ToolPreparation`].
+/// Paths are normalized workspace-relative; each `expected` state is the CAS
+/// precondition revalidated against the live workspace immediately before the
+/// operation. Directory operations carry no candidate bytes.
+pub(crate) enum PathMutationCandidate {
+    /// Create a new directory. Precondition: the leaf is `Absent`.
+    CreateDir { path: String, success: String },
+    /// Remove a regular file or an empty directory. `expected` is the observed
+    /// `File` or `Directory` state; a non-empty directory is rejected at commit.
+    Delete {
+        path: String,
+        expected: PathState,
+        success: String,
+    },
+    /// Rename `from` to `to`. Precondition: `from` matches `from_expected` and
+    /// `to` is `Absent` (no implicit overwrite).
+    Move {
+        from: String,
+        from_expected: PathState,
+        to: String,
+        success: String,
+    },
 }
 
 /// Side-effect-free tool preparation returned through the controlled registry
@@ -451,6 +480,13 @@ impl ToolPreparation {
         Self {
             intent: PreparedIntent::Mutation(intent),
             execution: PreparedExecution::FileMutation(candidate),
+        }
+    }
+
+    pub(crate) fn path_mutation(intent: MutationIntent, candidate: PathMutationCandidate) -> Self {
+        Self {
+            intent: PreparedIntent::Mutation(intent),
+            execution: PreparedExecution::PathMutation(candidate),
         }
     }
 }

--- a/crates/ferric-tools/src/registry.rs
+++ b/crates/ferric-tools/src/registry.rs
@@ -511,6 +511,11 @@ impl Registry {
                     crate::builtin::controlled_file::commit_candidate(workspace, operation);
                 (result.full, result.is_error, result.effects, result.failure)
             }
+            PreparedExecution::PathMutation(candidate) => {
+                let result =
+                    crate::builtin::controlled_file::commit_path_mutation(workspace, candidate);
+                (result.full, result.is_error, result.effects, result.failure)
+            }
         };
         let duration_ms =
             preparation_duration_ms.saturating_add(started.elapsed().as_millis() as u64);

--- a/crates/ferric-tools/tests/controlled_registry.rs
+++ b/crates/ferric-tools/tests/controlled_registry.rs
@@ -316,9 +316,13 @@ fn controlled_enumeration_and_preparation_use_the_exact_explicit_allowlist() {
         controlled,
         [
             "apply_patch",
+            "copy_file",
+            "delete_path",
             "edit_file",
             "find_files",
             "list_dir",
+            "make_dir",
+            "move_path",
             "multi_edit",
             "read_file",
             "run_check",
@@ -328,14 +332,10 @@ fn controlled_enumeration_and_preparation_use_the_exact_explicit_allowlist() {
     );
 
     let opaque = [
-        "copy_file",
-        "delete_path",
         "fetch_reference",
         "git_read",
         "git_write",
-        "make_dir",
         "manage_task",
-        "move_path",
         "shell_exec",
     ];
     let (_directory, workspace) = workspace();

--- a/crates/ferric-tools/tests/controlled_structural.rs
+++ b/crates/ferric-tools/tests/controlled_structural.rs
@@ -1,0 +1,323 @@
+//! Structural filesystem mutations (make_dir / delete_path / move_path /
+//! copy_file) under the evidence-controlled registry path: typed intent, CAS on
+//! the prepared precondition, and measured, directory-aware effects.
+
+use ferric_guard::{Provenance, SinkPolicy, Workspace};
+use ferric_tools::{
+    ControlledOutcome, MutationKind, PrepareError, PrepareErrorKind, PrepareOutcome,
+    PreparedIntent, Registry, WorkspaceEffect, WorkspaceEffectKind, WorkspaceEffectReport,
+    register_builtin_tools,
+};
+use serde_json::{Value, json};
+
+fn setup() -> (tempfile::TempDir, Workspace, Registry) {
+    let directory = tempfile::tempdir().unwrap();
+    let workspace = Workspace::new(directory.path()).unwrap();
+    let mut registry = Registry::new();
+    register_builtin_tools(&mut registry);
+    (directory, workspace, registry)
+}
+
+fn prepared(
+    registry: &Registry,
+    workspace: &Workspace,
+    name: &str,
+    args: &Value,
+) -> PreparedIntent {
+    let (intent, outcome) = commit(registry, workspace, name, args);
+    assert!(
+        !errored(&outcome),
+        "{name} unexpectedly errored: {outcome:?}"
+    );
+    intent
+}
+
+fn commit(
+    registry: &Registry,
+    workspace: &Workspace,
+    name: &str,
+    args: &Value,
+) -> (PreparedIntent, ControlledOutcome) {
+    let prepared = match registry.prepare_controlled(workspace, name, args) {
+        PrepareOutcome::Prepared(prepared) => prepared,
+        other => panic!("expected controlled preparation for {name}, got {other:?}"),
+    };
+    let intent = prepared.intent().clone();
+    let outcome = registry.commit_admitted(prepared, Provenance::Clean, &SinkPolicy::deny(), None);
+    (intent, outcome)
+}
+
+fn reject(registry: &Registry, workspace: &Workspace, name: &str, args: &Value) -> PrepareError {
+    match registry.prepare_controlled(workspace, name, args) {
+        PrepareOutcome::Rejected { error, .. } => error,
+        other => panic!("expected {name} preparation to be rejected, got {other:?}"),
+    }
+}
+
+fn mutation_kind(intent: &PreparedIntent) -> MutationKind {
+    match intent {
+        PreparedIntent::Mutation(intent) => intent.kind,
+        other => panic!("expected a mutation intent, got {other:?}"),
+    }
+}
+
+fn effects(outcome: &ControlledOutcome) -> Vec<WorkspaceEffect> {
+    match outcome {
+        ControlledOutcome::Completed { metadata, .. } => match &metadata.effects {
+            WorkspaceEffectReport::Measured(effects) => effects.clone(),
+            other => panic!("expected measured effects, got {other:?}"),
+        },
+        other => panic!("expected completion, got {other:?}"),
+    }
+}
+
+fn errored(outcome: &ControlledOutcome) -> bool {
+    match outcome {
+        ControlledOutcome::Completed { output, .. } => output.is_error,
+        ControlledOutcome::Denied { .. } => true,
+    }
+}
+
+fn is_stale(outcome: &ControlledOutcome) -> bool {
+    matches!(
+        outcome,
+        ControlledOutcome::Completed { metadata, .. }
+            if metadata.failure.as_ref().is_some_and(|failure| {
+                failure.kind == ferric_tools::ControlFailureKind::StalePrecondition
+            })
+    )
+}
+
+#[test]
+fn make_dir_creates_a_directory_with_a_measured_effect() {
+    let (dir, workspace, registry) = setup();
+    let (intent, outcome) = commit(&registry, &workspace, "make_dir", &json!({"path": "proj"}));
+    assert_eq!(mutation_kind(&intent), MutationKind::CreateDirectory);
+    assert!(!errored(&outcome));
+    assert!(dir.path().join("proj").is_dir());
+
+    let effects = effects(&outcome);
+    assert_eq!(effects.len(), 1);
+    assert_eq!(effects[0].path, "proj");
+    assert_eq!(effects[0].kind, WorkspaceEffectKind::CreatedDirectory);
+}
+
+#[test]
+fn make_dir_into_a_missing_parent_is_rejected() {
+    let (_dir, workspace, registry) = setup();
+    let error = reject(
+        &registry,
+        &workspace,
+        "make_dir",
+        &json!({"path": "absent/child"}),
+    );
+    assert!(
+        error.message.contains("does not exist"),
+        "message: {}",
+        error.message
+    );
+}
+
+#[test]
+fn make_dir_on_an_existing_directory_is_a_no_effect() {
+    let (dir, workspace, registry) = setup();
+    std::fs::create_dir(dir.path().join("proj")).unwrap();
+    let error = reject(&registry, &workspace, "make_dir", &json!({"path": "proj"}));
+    assert_eq!(error.kind, PrepareErrorKind::NoEffect);
+}
+
+#[test]
+fn make_dir_over_an_existing_file_is_unsupported() {
+    let (dir, workspace, registry) = setup();
+    std::fs::write(dir.path().join("proj"), b"i am a file").unwrap();
+    let error = reject(&registry, &workspace, "make_dir", &json!({"path": "proj"}));
+    assert_eq!(error.kind, PrepareErrorKind::UnsupportedOperation);
+}
+
+#[test]
+fn delete_removes_a_file_with_a_deleted_effect() {
+    let (dir, workspace, registry) = setup();
+    std::fs::write(dir.path().join("junk.txt"), b"bye").unwrap();
+    let (intent, outcome) = commit(
+        &registry,
+        &workspace,
+        "delete_path",
+        &json!({"path": "junk.txt"}),
+    );
+    assert_eq!(mutation_kind(&intent), MutationKind::DeleteFile);
+    assert!(!errored(&outcome));
+    assert!(!dir.path().join("junk.txt").exists());
+
+    let effects = effects(&outcome);
+    assert_eq!(effects[0].kind, WorkspaceEffectKind::Deleted);
+}
+
+#[test]
+fn delete_removes_an_empty_directory_with_a_directory_effect() {
+    let (dir, workspace, registry) = setup();
+    std::fs::create_dir(dir.path().join("temp")).unwrap();
+    let (intent, outcome) = commit(
+        &registry,
+        &workspace,
+        "delete_path",
+        &json!({"path": "temp"}),
+    );
+    assert_eq!(mutation_kind(&intent), MutationKind::DeleteDirectory);
+    assert!(!errored(&outcome));
+    assert!(!dir.path().join("temp").exists());
+
+    let effects = effects(&outcome);
+    assert_eq!(effects[0].kind, WorkspaceEffectKind::DeletedDirectory);
+}
+
+#[test]
+fn delete_of_a_non_empty_directory_is_unsupported() {
+    let (dir, workspace, registry) = setup();
+    std::fs::create_dir(dir.path().join("full")).unwrap();
+    std::fs::write(dir.path().join("full/keep.txt"), b"x").unwrap();
+    let error = reject(
+        &registry,
+        &workspace,
+        "delete_path",
+        &json!({"path": "full"}),
+    );
+    assert_eq!(error.kind, PrepareErrorKind::UnsupportedOperation);
+    assert!(dir.path().join("full/keep.txt").exists());
+}
+
+#[test]
+fn delete_of_an_absent_path_is_a_no_effect() {
+    let (_dir, workspace, registry) = setup();
+    let error = reject(
+        &registry,
+        &workspace,
+        "delete_path",
+        &json!({"path": "ghost"}),
+    );
+    assert_eq!(error.kind, PrepareErrorKind::NoEffect);
+}
+
+#[test]
+fn move_file_renames_and_reports_a_deletion_and_a_creation() {
+    let (dir, workspace, registry) = setup();
+    std::fs::create_dir(dir.path().join("dest")).unwrap();
+    std::fs::write(dir.path().join("a.txt"), b"payload").unwrap();
+    let (intent, outcome) = commit(
+        &registry,
+        &workspace,
+        "move_path",
+        &json!({"from": "a.txt", "to": "dest/b.txt"}),
+    );
+    assert_eq!(mutation_kind(&intent), MutationKind::MovePath);
+    assert!(!errored(&outcome));
+    assert!(!dir.path().join("a.txt").exists());
+    assert_eq!(
+        std::fs::read(dir.path().join("dest/b.txt")).unwrap(),
+        b"payload"
+    );
+
+    let effects = effects(&outcome);
+    assert_eq!(effects.len(), 2);
+    let from = effects
+        .iter()
+        .find(|effect| effect.path == "a.txt")
+        .unwrap();
+    let to = effects
+        .iter()
+        .find(|effect| effect.path == "dest/b.txt")
+        .unwrap();
+    assert_eq!(from.kind, WorkspaceEffectKind::Deleted);
+    assert_eq!(to.kind, WorkspaceEffectKind::Created);
+}
+
+#[test]
+fn move_directory_reports_directory_effects() {
+    let (dir, workspace, registry) = setup();
+    std::fs::create_dir(dir.path().join("old")).unwrap();
+    let (_intent, outcome) = commit(
+        &registry,
+        &workspace,
+        "move_path",
+        &json!({"from": "old", "to": "new"}),
+    );
+    assert!(!errored(&outcome));
+    assert!(dir.path().join("new").is_dir());
+    assert!(!dir.path().join("old").exists());
+
+    let effects = effects(&outcome);
+    let from = effects.iter().find(|effect| effect.path == "old").unwrap();
+    let to = effects.iter().find(|effect| effect.path == "new").unwrap();
+    assert_eq!(from.kind, WorkspaceEffectKind::DeletedDirectory);
+    assert_eq!(to.kind, WorkspaceEffectKind::CreatedDirectory);
+}
+
+#[test]
+fn move_onto_an_existing_destination_is_unsupported() {
+    let (dir, workspace, registry) = setup();
+    std::fs::write(dir.path().join("a.txt"), b"a").unwrap();
+    std::fs::write(dir.path().join("b.txt"), b"b").unwrap();
+    let error = reject(
+        &registry,
+        &workspace,
+        "move_path",
+        &json!({"from": "a.txt", "to": "b.txt"}),
+    );
+    assert_eq!(error.kind, PrepareErrorKind::UnsupportedOperation);
+    // Neither endpoint was touched.
+    assert_eq!(std::fs::read(dir.path().join("a.txt")).unwrap(), b"a");
+    assert_eq!(std::fs::read(dir.path().join("b.txt")).unwrap(), b"b");
+}
+
+#[test]
+fn copy_file_publishes_source_bytes_at_a_new_destination() {
+    let (dir, workspace, registry) = setup();
+    std::fs::write(dir.path().join("src.txt"), b"copy me").unwrap();
+    let intent = prepared(
+        &registry,
+        &workspace,
+        "copy_file",
+        &json!({"from": "src.txt", "to": "dst.txt"}),
+    );
+    // A copy to a new path is a file creation.
+    assert_eq!(mutation_kind(&intent), MutationKind::CreateFile);
+    assert_eq!(
+        std::fs::read(dir.path().join("dst.txt")).unwrap(),
+        b"copy me"
+    );
+    assert_eq!(
+        std::fs::read(dir.path().join("src.txt")).unwrap(),
+        b"copy me"
+    );
+}
+
+#[test]
+fn copy_of_a_directory_source_is_unsupported() {
+    let (dir, workspace, registry) = setup();
+    std::fs::create_dir(dir.path().join("adir")).unwrap();
+    let error = reject(
+        &registry,
+        &workspace,
+        "copy_file",
+        &json!({"from": "adir", "to": "dst"}),
+    );
+    assert_eq!(error.kind, PrepareErrorKind::UnsupportedOperation);
+}
+
+#[test]
+fn a_state_change_between_preparation_and_commit_is_a_stale_precondition() {
+    let (dir, workspace, registry) = setup();
+    // Prepare a make_dir whose precondition is "target is absent".
+    let prepared =
+        match registry.prepare_controlled(&workspace, "make_dir", &json!({"path": "race"})) {
+            PrepareOutcome::Prepared(prepared) => prepared,
+            other => panic!("expected preparation, got {other:?}"),
+        };
+    // The workspace changes underneath the sealed preparation.
+    std::fs::create_dir(dir.path().join("race")).unwrap();
+    let outcome = registry.commit_admitted(prepared, Provenance::Clean, &SinkPolicy::deny(), None);
+    assert!(errored(&outcome), "a stale commit must not report success");
+    assert!(
+        is_stale(&outcome),
+        "expected a stale precondition, got {outcome:?}"
+    );
+}

--- a/crates/ferric-trace/src/event.rs
+++ b/crates/ferric-trace/src/event.rs
@@ -196,6 +196,12 @@ pub enum PathEffectKind {
     Created,
     Modified,
     Deleted,
+    /// A directory came into existence (`make_dir`, or the destination of a
+    /// directory move). Structural effects carry no content digest.
+    CreatedDirectory,
+    /// A directory ceased to exist (`delete_path` on an empty directory, or the
+    /// source of a directory move).
+    DeletedDirectory,
     Opaque,
 }
 


### PR DESCRIPTION
Closes the evidence-mode gap found live in the previous session: `--harness-policy evidence` excluded every structural filesystem tool, so it could not create a directory (the model hit "unsupported controlled mutation target" and gave up). `make_dir`/`delete_path`/`move_path`/`copy_file` now work under evidence control with the controller's full guarantees.

## What changed
- Each structural tool declares `ControlCapability::ContentMutation` + a typed `prepare()`. `copy_file` reuses the existing content-mutation commit (candidate = source bytes); `make_dir`/`delete_path`/`move_path` use a new `commit_path_mutation` that re-observes the leaf through a **capability-pinned parent**, **CASes** it against the prepared precondition (a change between prepare and commit is a stale precondition, not a blind action), and records **measured, directory-aware** effects (`move` emits two).
- Directory effects flow end-to-end: new `PathEffectKind::{CreatedDirectory,DeletedDirectory}` (+ `WorkspaceEffectKind` twins). The controller's `mutation_block` accepts a `Directory` precondition (existence/type CAS, no content evidence), `validate_workspace_effect_shape` accepts the dir kinds, and `trace_structure`'s effect-tool allowlist covers the structural tools so their traces **verify and resume**.
- `delete_path` handles a file or an **empty** directory (non-empty is unsupported); `move_path` does not implicitly overwrite; `make_dir` requires the parent to exist. `shell_exec`/`git_*` stay opaque by design.

## Verification
- `cargo fmt --check` clean; `cargo clippy --all-targets -D warnings` clean (default and `--features backend-openai`).
- Workspace suite green on **Windows (903)** and **Linux (WSL)**; **15 new tests** (structural prepare/commit/CAS/effects, directory preconditions, effect-tool allowlist).
- **Live (real qwen2.5-coder-7b):** the exact previously-failing task — create `proj`, write `proj/calc.py`, create then delete `scratch` — completes under `--harness-policy evidence` in 5 turns with `task_complete`, correct artifacts, **2 `created_directory` + 1 `deleted_directory`** trace effects, and a clean side-effect-free `trace verify`.

## Not in scope (deliberate follow-ups)
Recursive non-empty-directory delete; implicit `move_path` overwrite; the (deferred) T-11307 real-model paired evaluation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)